### PR TITLE
Fix travis error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,11 @@ matrix:
     - python: 3.6
       env: TOXENV=py36
 install:
-  - pip install pipenv codecov
-  - pipenv install --dev
+  - pip install tox codecov awscli
 before_script:
-  - pipenv run ./scripts/test_data/upload_test_data.sh
+  - ./scripts/test_data/upload_test_data.sh
 script:
-  - pipenv run tox
+  - tox
 after_success:
-  # - pipenv run ./scripts/test_data/delete_test_data.sh
+  # - ./scripts/test_data/delete_test_data.sh
   - codecov

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,12 @@
 envlist = py27,py34,py35,py36
 
 [testenv]
-deps = pipenv
+deps =
+    SQLAlchemy>=1.0.0
+    pytest>=3.5
+    pytest-cov
+    pytest-flake8>=1.0.1
 commands =
-    pipenv install --dev
-    pipenv run pytest --cov pyathena --cov-report html --cov-report term --flake8
+    pytest --cov pyathena --cov-report html --cov-report term --flake8
 passenv =
     AWS_*


### PR DESCRIPTION
```
$ pipenv install --dev
Courtesy Notice: Pipenv found itself running within a virtual environment, so it will automatically use that environment, instead of creating its own for any project. You can set PIPENV_IGNORE_VIRTUALENVS=1 to force pipenv to ignore that environment and create its own instead.
Installing dependencies from Pipfile.lock (f13624)...
Traceback (most recent call last):
  File "/home/travis/virtualenv/python2.7.14/bin/pipenv", line 11, in <module>
    sys.exit(cli())
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pipenv/vendor/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pipenv/vendor/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pipenv/vendor/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pipenv/vendor/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pipenv/vendor/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pipenv/cli.py", line 416, in install
    selective_upgrade=selective_upgrade,
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pipenv/core.py", line 1972, in do_install
    pypi_mirror=pypi_mirror,
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pipenv/core.py", line 1356, in do_init
    pypi_mirror=pypi_mirror,
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pipenv/core.py", line 823, in do_install_dependencies
    pypi_mirror=pypi_mirror,
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pipenv/core.py", line 1409, in pip_install
    package_name.split('--hash')[0].split('--trusted-host')[0]
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pipenv/vendor/requirementslib/models/requirements.py", line 701, in from_line
    r = FileRequirement.from_line(line_with_prefix)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pipenv/vendor/requirementslib/models/requirements.py", line 338, in from_line
    created = cls(**arg_dict)
  File "<attrs generated init 4da89d6d4b27ad14e2580f94c5f4e457114d0a77>", line 16, in __init__
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pipenv/vendor/requirementslib/models/requirements.py", line 240, in get_name
    dist = run_setup(self.setup_path.as_posix(), stop_after="init")
  File "/opt/python/2.7.14/lib/python2.7/distutils/core.py", line 218, in run_setup
    exec f.read() in g, l
  File "<string>", line 9, in <module>
ImportError: No module named pyathena
/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pipenv/_compat.py:108: ResourceWarning: Implicitly cleaning up <TemporaryDirectory '/tmp/pipenv-F73eSJ-requirements'>
  warnings.warn(warn_message, ResourceWarning)
The command "pipenv install --dev" failed and exited with 1 during .
```