### PR TITLE
Fix to make it None when SQLAlchemy's URI username and password are empty strings

### DIFF
--- a/pyathena/sqlalchemy_athena.py
+++ b/pyathena/sqlalchemy_athena.py
@@ -95,8 +95,8 @@ class AthenaDialect(DefaultDialect):
         #   {aws_access_key_id}:{aws_secret_access_key}@athena.{region_name}.amazonaws.com:443/
         #   {schema_name}?s3_staging_dir={s3_staging_dir}&...
         opts = {
-            'aws_access_key_id': url.username,
-            'aws_secret_access_key': url.password,
+            'aws_access_key_id': url.username if url.username else None,
+            'aws_secret_access_key': url.password if url.password else None,
             'region_name': re.sub(r'^athena\.([a-z0-9-]+)\.amazonaws\.com$', r'\1', url.host),
             'schema_name': url.database if url.database else 'default'
         }


### PR DESCRIPTION
fix #54 