### PR TITLE
Allow empty results from PandasCursor.

### DIFF
--- a/pyathena/result_set.py
+++ b/pyathena/result_set.py
@@ -390,12 +390,16 @@ class AthenaPandasResultSet(AthenaResultSet):
             _logger.exception('Failed to download csv.')
             raise_from(OperationalError(*e.args), e)
         else:
-            df = pd.read_csv(io.BytesIO(response['Body'].read()),
-                             dtype=self._dtypes(),
-                             converters=self._converters(),
-                             parse_dates=self._parse_dates(),
-                             infer_datetime_format=True)
-            df = self._trunc_date(df)
+            buf = io.BytesIO(response['Body'].read())
+            if buf.getbuffer():
+                df = pd.read_csv(buf,
+                                 dtype=self._dtypes(),
+                                 converters=self._converters(),
+                                 parse_dates=self._parse_dates(),
+                                 infer_datetime_format=True)
+                df = self._trunc_date(df)
+            else:     # Allow empty response so DDL can be used
+                df = pd.DataFrame()
             return df
 
     def as_pandas(self):


### PR DESCRIPTION
When running SQL statements without a result, such as DDL, PandasCursor would try to make a dataframe from an empty CSV file, which would crash.

This returns an empty DataFrame, allowing the use of DDL without error.