### PR TITLE
Restrict the allowable version of SQLAlchemy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     ],
     extras_require={
         'Pandas': ['pandas>=0.19.0'],
-        'SQLAlchemy': ['SQLAlchemy>=1.0.0'],
+        'SQLAlchemy': ['SQLAlchemy>=1.0.0, <1.3.0'],
     },
     tests_require=[
         'SQLAlchemy>=1.0.0',

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py27,py34,py35,py36
 
 [testenv]
 deps =
-    SQLAlchemy>=1.0.0
+    SQLAlchemy>=1.0.0, <1.3.0
     pandas>=0.19.0
     pytest>=3.5
     pytest-cov


### PR DESCRIPTION
```
=================================== FAILURES ===================================
___________ TestSQLAlchemyAthena.test_reflect_table_include_columns ____________
self = <tests.test_sqlalchemy_athena.TestSQLAlchemyAthena testMethod=test_reflect_table_include_columns>
engine = Engine(awsathena+rest://athena.[secure].amazonaws.com:443/test_pyathena_g7ss5pxv6v?s3_staging_dir=[secure])
connection = <sqlalchemy.engine.base.Connection object at 0x7fac049e4c88>
    @with_engine
    def test_reflect_table_include_columns(self, engine, connection):
        one_row_complex = Table('one_row_complex', MetaData(bind=engine))
        engine.dialect.reflecttable(
>           connection, one_row_complex, include_columns=['col_int'], exclude_columns=[])
E       TypeError: reflecttable() missing 1 required positional argument: 'resolve_fks'
tests/test_sqlalchemy_athena.py:76: TypeError
```