### PR TITLE
Stop bundling tests when packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author='laughingman7743',
     author_email='laughingman7743@gmail.com',
     license='MIT License',
-    packages=find_packages(),
+    packages=find_packages('.', exclude=['tests']),
     package_data={
         '': ['LICENSE', '*.rst', 'Pipfile*'],
     },


### PR DESCRIPTION
Before this the tests would be installed alongside the package, meaning that
there'd be a global tests package installed alongside pyathena.

As a user of pyathena I don't need the tests in production and would rather 
not have them installed. :)


I tested this locally and running without this change I saw:

```shell
$ python setup.py sdist
running sdist
running egg_info
writing PyAthena.egg-info/PKG-INFO
writing dependency_links to PyAthena.egg-info/dependency_links.txt
writing entry points to PyAthena.egg-info/entry_points.txt
writing requirements to PyAthena.egg-info/requires.txt
writing top-level names to PyAthena.egg-info/top_level.txt
reading manifest file 'PyAthena.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'PyAthena.egg-info/SOURCES.txt'
running check
creating PyAthena-1.7.0
creating PyAthena-1.7.0/PyAthena.egg-info
creating PyAthena-1.7.0/pyathena
creating PyAthena-1.7.0/tests
copying files to PyAthena-1.7.0...
copying LICENSE -> PyAthena-1.7.0
copying MANIFEST.in -> PyAthena-1.7.0
copying Pipfile -> PyAthena-1.7.0
copying Pipfile.lock -> PyAthena-1.7.0
copying README.rst -> PyAthena-1.7.0
copying setup.cfg -> PyAthena-1.7.0
copying setup.py -> PyAthena-1.7.0
copying PyAthena.egg-info/PKG-INFO -> PyAthena-1.7.0/PyAthena.egg-info
copying PyAthena.egg-info/SOURCES.txt -> PyAthena-1.7.0/PyAthena.egg-info
copying PyAthena.egg-info/dependency_links.txt -> PyAthena-1.7.0/PyAthena.egg-info
copying PyAthena.egg-info/entry_points.txt -> PyAthena-1.7.0/PyAthena.egg-info
copying PyAthena.egg-info/not-zip-safe -> PyAthena-1.7.0/PyAthena.egg-info
copying PyAthena.egg-info/requires.txt -> PyAthena-1.7.0/PyAthena.egg-info
copying PyAthena.egg-info/top_level.txt -> PyAthena-1.7.0/PyAthena.egg-info
copying pyathena/__init__.py -> PyAthena-1.7.0/pyathena
copying pyathena/async_cursor.py -> PyAthena-1.7.0/pyathena
copying pyathena/async_pandas_cursor.py -> PyAthena-1.7.0/pyathena
copying pyathena/common.py -> PyAthena-1.7.0/pyathena
copying pyathena/connection.py -> PyAthena-1.7.0/pyathena
copying pyathena/converter.py -> PyAthena-1.7.0/pyathena
copying pyathena/cursor.py -> PyAthena-1.7.0/pyathena
copying pyathena/error.py -> PyAthena-1.7.0/pyathena
copying pyathena/formatter.py -> PyAthena-1.7.0/pyathena
copying pyathena/model.py -> PyAthena-1.7.0/pyathena
copying pyathena/pandas_cursor.py -> PyAthena-1.7.0/pyathena
copying pyathena/result_set.py -> PyAthena-1.7.0/pyathena
copying pyathena/sqlalchemy_athena.py -> PyAthena-1.7.0/pyathena
copying pyathena/util.py -> PyAthena-1.7.0/pyathena
copying tests/__init__.py -> PyAthena-1.7.0/tests
copying tests/conftest.py -> PyAthena-1.7.0/tests
copying tests/test_async_cursor.py -> PyAthena-1.7.0/tests
copying tests/test_async_pandas_cursor.py -> PyAthena-1.7.0/tests
copying tests/test_cursor.py -> PyAthena-1.7.0/tests
copying tests/test_formatter.py -> PyAthena-1.7.0/tests
copying tests/test_pandas_cursor.py -> PyAthena-1.7.0/tests
copying tests/test_result_set.py -> PyAthena-1.7.0/tests
copying tests/test_sqlalchemy_athena.py -> PyAthena-1.7.0/tests
copying tests/util.py -> PyAthena-1.7.0/tests
Writing PyAthena-1.7.0/setup.cfg
Creating tar archive
removing 'PyAthena-1.7.0' (and everything under it)
```
And after introducing these changes we package this:

```shell
$ python setup.py sdist
running sdist
running egg_info
creating PyAthena.egg-info
writing PyAthena.egg-info/PKG-INFO
writing dependency_links to PyAthena.egg-info/dependency_links.txt
writing entry points to PyAthena.egg-info/entry_points.txt
writing requirements to PyAthena.egg-info/requires.txt
writing top-level names to PyAthena.egg-info/top_level.txt
writing manifest file 'PyAthena.egg-info/SOURCES.txt'
reading manifest file 'PyAthena.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'PyAthena.egg-info/SOURCES.txt'
running check
creating PyAthena-1.7.0
creating PyAthena-1.7.0/PyAthena.egg-info
creating PyAthena-1.7.0/pyathena
copying files to PyAthena-1.7.0...
copying LICENSE -> PyAthena-1.7.0
copying MANIFEST.in -> PyAthena-1.7.0
copying Pipfile -> PyAthena-1.7.0
copying Pipfile.lock -> PyAthena-1.7.0
copying README.rst -> PyAthena-1.7.0
copying setup.cfg -> PyAthena-1.7.0
copying setup.py -> PyAthena-1.7.0
copying PyAthena.egg-info/PKG-INFO -> PyAthena-1.7.0/PyAthena.egg-info
copying PyAthena.egg-info/SOURCES.txt -> PyAthena-1.7.0/PyAthena.egg-info
copying PyAthena.egg-info/dependency_links.txt -> PyAthena-1.7.0/PyAthena.egg-info
copying PyAthena.egg-info/entry_points.txt -> PyAthena-1.7.0/PyAthena.egg-info
copying PyAthena.egg-info/not-zip-safe -> PyAthena-1.7.0/PyAthena.egg-info
copying PyAthena.egg-info/requires.txt -> PyAthena-1.7.0/PyAthena.egg-info
copying PyAthena.egg-info/top_level.txt -> PyAthena-1.7.0/PyAthena.egg-info
copying pyathena/__init__.py -> PyAthena-1.7.0/pyathena
copying pyathena/async_cursor.py -> PyAthena-1.7.0/pyathena
copying pyathena/async_pandas_cursor.py -> PyAthena-1.7.0/pyathena
copying pyathena/common.py -> PyAthena-1.7.0/pyathena
copying pyathena/connection.py -> PyAthena-1.7.0/pyathena
copying pyathena/converter.py -> PyAthena-1.7.0/pyathena
copying pyathena/cursor.py -> PyAthena-1.7.0/pyathena
copying pyathena/error.py -> PyAthena-1.7.0/pyathena
copying pyathena/formatter.py -> PyAthena-1.7.0/pyathena
copying pyathena/model.py -> PyAthena-1.7.0/pyathena
copying pyathena/pandas_cursor.py -> PyAthena-1.7.0/pyathena
copying pyathena/result_set.py -> PyAthena-1.7.0/pyathena
copying pyathena/sqlalchemy_athena.py -> PyAthena-1.7.0/pyathena
copying pyathena/util.py -> PyAthena-1.7.0/pyathena
Writing PyAthena-1.7.0/setup.cfg
creating dist
Creating tar archive
removing 'PyAthena-1.7.0' (and everything under it)
```

As you can see, no tests bundled! :)