### PR TITLE
Fix broken test cases

### DIFF
--- a/tests/test_async_cursor.py
+++ b/tests/test_async_cursor.py
@@ -157,7 +157,7 @@ class TestAsyncCursor(unittest.TestCase):
         cursor.cancel(query_id)
         result_set = future.result()
         self.assertEqual(result_set.state, AthenaQueryExecution.STATE_CANCELLED)
-        self.assertIsNone(result_set.state_change_reason)
+        self.assertIsNotNone(result_set.state_change_reason)
         self.assertIsNone(result_set.description)
         self.assertIsNone(result_set.fetchone())
         self.assertEqual(result_set.fetchmany(), [])

--- a/tests/test_async_pandas_cursor.py
+++ b/tests/test_async_pandas_cursor.py
@@ -176,7 +176,7 @@ class TestAsyncCursor(unittest.TestCase):
         cursor.cancel(query_id)
         result_set = future.result()
         self.assertEqual(result_set.state, AthenaQueryExecution.STATE_CANCELLED)
-        self.assertIsNone(result_set.state_change_reason)
+        self.assertIsNotNone(result_set.state_change_reason)
         self.assertIsNone(result_set.description)
         self.assertIsNone(result_set.fetchone())
         self.assertEqual(result_set.fetchmany(), [])


### PR DESCRIPTION
https://travis-ci.org/laughingman7743/PyAthena/builds/567453898
```
=================================== FAILURES ===================================
_________________________ TestAsyncCursor.test_cancel __________________________

self = <tests.test_async_cursor.TestAsyncCursor testMethod=test_cancel>
cursor = <pyathena.async_cursor.AsyncCursor object at 0x7f1a9362f278>

    @with_async_cursor
    def test_cancel(self, cursor):
        query_id, future = cursor.execute("""
                           SELECT a.a * rand(), b.a * rand()
                           FROM many_rows a
                           CROSS JOIN many_rows b
                           """)
        time.sleep(randint(1, 5))
        cursor.cancel(query_id)
        result_set = future.result()
        self.assertEqual(result_set.state, AthenaQueryExecution.STATE_CANCELLED)
>       self.assertIsNone(result_set.state_change_reason)
E       AssertionError: 'Query cancelled by user' is not None

tests/test_async_cursor.py:160: AssertionError
_________________________ TestAsyncCursor.test_cancel __________________________

self = <tests.test_async_pandas_cursor.TestAsyncCursor testMethod=test_cancel>
cursor = <pyathena.async_pandas_cursor.AsyncPandasCursor object at 0x7f1a91cc12b0>

    @with_async_pandas_cursor
    def test_cancel(self, cursor):
        query_id, future = cursor.execute("""
                           SELECT a.a * rand(), b.a * rand()
                           FROM many_rows a
                           CROSS JOIN many_rows b
                           """)
        time.sleep(randint(1, 5))
        cursor.cancel(query_id)
        result_set = future.result()
        self.assertEqual(result_set.state, AthenaQueryExecution.STATE_CANCELLED)
>       self.assertIsNone(result_set.state_change_reason)
E       AssertionError: 'Query cancelled by user' is not None
```