### PR TITLE
Check that the column_default is not nan

### DIFF
--- a/tests/test_sqlalchemy_athena.py
+++ b/tests/test_sqlalchemy_athena.py
@@ -295,3 +295,10 @@ class TestSQLAlchemyAthena(unittest.TestCase):
         """)
         result = engine.execute(query, param='b%')
         self.assertEqual(result.fetchall(), [('a string', )])
+
+    @with_engine
+    def test_nan_checks(self, engine, connection):
+        dialect = engine.dialect
+        self.assertFalse(dialect._is_nan("string"))
+        self.assertFalse(dialect._is_nan(1))
+        self.assertTrue(dialect._is_nan(float('nan')))


### PR DESCRIPTION
It seems that for tables generated using aws glue the `column_default`
in the table descripion is returned as `nan` rather than `None`. This
makes sqlalchemy to crash when processing the columns definition as it
expects a string or TextClause.
https://github.com/sqlalchemy/sqlalchemy/blob/60e64a2c35e7e5a0125c5fefbf0caf531eeb2eda/lib/sqlalchemy/engine/reflection.py#L734

This commit checks the value of the `column_default` and sets it to
`None` in case it  is `nan`.

For the code
```python
Table('table_name', MetaData(bind=conn), autoload=True)
```

The error that we were getting before this fix was

```
[...]

~/.pyenv/versions/3.6.8/envs/virtualenv/lib/python3.6/site-packages/sqlalchemy/sql/schema.py in __new__(cls, *args, **kw)
    489             metadata._add_table(name, schema, table)
    490             try:
--> 491                 table._init(name, metadata, *args, **kw)
    492                 table.dispatch.after_parent_attach(table, metadata)
    493                 return table
~/.pyenv/versions/3.6.8/envs/virtualenv/lib/python3.6/site-packages/sqlalchemy/sql/schema.py in _init(self, name, metadata, *args, **kwargs)
    583                 include_columns,
    584                 _extend_on=_extend_on,
--> 585                 resolve_fks=resolve_fks,
    586             )
    587
~/.pyenv/versions/3.6.8/envs/virtualenv/lib/python3.6/site-packages/sqlalchemy/sql/schema.py in _autoload(self, metadata, autoload_with, include_columns, exclude_columns, resolve_fks, _extend_on)
    624                 exclude_columns,
    625                 resolve_fks,
--> 626                 _extend_on=_extend_on,
    627             )
    628
~/.pyenv/versions/3.6.8/envs/virtualenv/lib/python3.6/site-packages/sqlalchemy/engine/base.py in run_callable(self, callable_, *args, **kwargs)
   1610
   1611         """
-> 1612         return callable_(self, *args, **kwargs)
   1613
   1614     def _run_visitor(self, visitorcallable, element, **kwargs):
~/.pyenv/versions/3.6.8/envs/virtualenv/lib/python3.6/site-packages/sqlalchemy/engine/default.py in reflecttable(self, connection, table, include_columns, exclude_columns, resolve_fks, **opts)
    429         insp = reflection.Inspector.from_engine(connection)
    430         return insp.reflecttable(
--> 431             table, include_columns, exclude_columns, resolve_fks, **opts
    432         )
    433
~/.pyenv/versions/3.6.8/envs/virtualenv/lib/python3.6/site-packages/sqlalchemy/engine/reflection.py in reflecttable(self, table, include_columns, exclude_columns, resolve_fks, _extend_on)
    653                 include_columns,
    654                 exclude_columns,
--> 655                 cols_by_orig_name,
    656             )
    657
~/.pyenv/versions/3.6.8/envs/virtualenv/lib/python3.6/site-packages/sqlalchemy/engine/reflection.py in _reflect_column(self, table, col_d, include_columns, exclude_columns, cols_by_orig_name)
    749             elif not isinstance(default, sa_schema.FetchedValue):
    750                 default = sa_schema.DefaultClause(
--> 751                     sql.text(col_d["default"]), _reflected=True
    752                 )
    753
<string> in text(text, bind, bindparams, typemap, autocommit)
<string> in _create_text(self, text, bind, bindparams, typemap, autocommit)
~/.pyenv/versions/3.6.8/envs/virtualenv/lib/python3.6/site-packages/sqlalchemy/util/deprecations.py in warned(fn, *args, **kwargs)
    126                     )
    127
--> 128             return fn(*args, **kwargs)
    129
    130         doc = fn.__doc__ is not None and fn.__doc__ or ""
~/.pyenv/versions/3.6.8/envs/virtualenv/lib/python3.6/site-packages/sqlalchemy/sql/elements.py in _create_text(self, text, bind, bindparams, typemap, autocommit)
   1484
   1485         """
-> 1486         stmt = TextClause(text, bind=bind)
   1487         if bindparams:
   1488             stmt = stmt.bindparams(*bindparams)
~/.pyenv/versions/3.6.8/envs/virtualenv/lib/python3.6/site-packages/sqlalchemy/sql/elements.py in __init__(self, text, bind)
   1348         # scan the string and search for bind parameter names, add them
   1349         # to the list of bindparams
-> 1350         self.text = self._bind_params_regex.sub(repl, text)
   1351
   1352     @classmethod
TypeError: expected string or bytes-like object

```