### PR TITLE
Cache results

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -597,7 +597,7 @@ As with AsynchronousCursor, you need a query ID to cancel a query.
 Quickly re-run queries
 ~~~~~~~~~~~~~~~~~~~~~~
 
-You can attempt to re-use the results from a previously run query to help save time and money in the cases where your underlying data isn't changing.
+You can attempt to re-use the results from a previously run query to help save time and money in the cases where your underlying data isn't changing. Set the ``cache_size`` parameter of ``cursor.execute()`` to a number larger than 0 to enable cacheing.
 
 .. code:: python
 
@@ -608,9 +608,13 @@ You can attempt to re-use the results from a previously run query to help save t
                      s3_staging_dir='s3://YOUR_S3_BUCKET/path/to/',
                      region_name='us-west-2').cursor()
     cursor.execute("SELECT * FROM one_row")  # run once
-    print(cursor.fetchall())
-    cursor.execute("SELECT * FROM one_row", cache_size=10)  # doesn't re-run query
-    print(cursor.fetchall())
+    print(cursor.query_id)
+    cursor.execute("SELECT * FROM one_row", cache_size=10)  # re-use earlier results
+    print(cursor.query_id)  # You should expect to see the same Query ID
+
+Results will only be re-used if the query strings match *exactly*, and the query was a DML statement (the assumption being that you always want to re-run queries like ``CREATE TABLE`` and ``DROP TABLE``).
+
+The S3 staging directory is not checked, so it's possible that the location of the results is not in your provided ``s3_staging_dir``.
 
 Credentials
 -----------

--- a/README.rst
+++ b/README.rst
@@ -594,6 +594,24 @@ As with AsynchronousCursor, you need a query ID to cancel a query.
     query_id, future = cursor.execute("SELECT * FROM many_rows")
     cursor.cancel(query_id)
 
+Quickly re-run queries
+~~~~~~~~~~~~~~~~~~~~~~
+
+You can attempt to re-use the results from a previously run query to help save time and money in the cases where your underlying data isn't changing.
+
+.. code:: python
+
+    from pyathena import connect
+
+    cursor = connect(aws_access_key_id='YOUR_ACCESS_KEY_ID',
+                     aws_secret_access_key='YOUR_SECRET_ACCESS_KEY',
+                     s3_staging_dir='s3://YOUR_S3_BUCKET/path/to/',
+                     region_name='us-west-2').cursor()
+    cursor.execute("SELECT * FROM one_row")  # run once
+    print(cursor.fetchall())
+    cursor.execute("SELECT * FROM one_row", cache_size=10)  # doesn't re-run query
+    print(cursor.fetchall())
+
 Credentials
 -----------
 

--- a/pyathena/async_cursor.py
+++ b/pyathena/async_cursor.py
@@ -76,11 +76,13 @@ class AsyncCursor(BaseCursor):
             arraysize=self._arraysize,
             retry_config=self._retry_config)
 
-    def execute(self, operation, parameters=None, work_group=None, s3_staging_dir=None):
+    def execute(self, operation, parameters=None, work_group=None, s3_staging_dir=None,
+                cache_size=0):
         query_id = self._execute(operation,
                                  parameters=parameters,
                                  work_group=work_group,
-                                 s3_staging_dir=s3_staging_dir)
+                                 s3_staging_dir=s3_staging_dir,
+                                 cache_size=cache_size)
         return query_id, self._executor.submit(self._collect_result_set, query_id)
 
     def executemany(self, operation, seq_of_parameters):

--- a/pyathena/common.py
+++ b/pyathena/common.py
@@ -142,24 +142,53 @@ class BaseCursor(with_metaclass(ABCMeta, object)):
             })
         return request
 
-    def _execute(self, operation, parameters=None, work_group=None, s3_staging_dir=None):
+    def _find_previous_query_id(self, request, work_group, cache_size):
+        next_token = None
+        while cache_size > 0:
+            n = min(cache_size, 50)  # 50 is max allowed by AWS API
+            request_params = {'MaxResults': n}
+            if work_group is not None:
+                request_params['WorkGroup'] = work_group
+            if next_token is not None:
+                request_params['NextToken'] = next_token
+            response = self.connection._client.list_query_executions(**request_params)
+            cache_size -= n
+            query_ids = response['QueryExecutionIds']
+            next_token = response['NextToken']
+            query_executions = self.connection._client.batch_get_query_execution(
+                QueryExecutionIds=query_ids
+            )['QueryExecutions']
+            requested_location = request['ResultConfiguration']['OutputLocation']
+            for execution in query_executions:
+                queries_match = execution['Query'] == request['QueryString']
+                succeeded = execution['Status']['State'] == 'SUCCEEDED'
+                executed_location = execution['ResultConfiguration']['OutputLocation']
+                locations_match = executed_location == requested_location
+                is_dml = execution['StatementType'] == 'DML'
+                if queries_match and succeeded and locations_match and is_dml:
+                    return execution['QueryExecutionId']
+
+    def _execute(self, operation, parameters=None, work_group=None, s3_staging_dir=None,
+                 cache_size=0):
         query = self._formatter.format(operation, parameters)
         _logger.debug(query)
 
         request = self._build_start_query_execution_request(query, work_group, s3_staging_dir)
-        try:
-            response = retry_api_call(self._connection.client.start_query_execution,
-                                      config=self._retry_config,
-                                      logger=_logger,
-                                      **request)
-        except Exception as e:
-            _logger.exception('Failed to execute query.')
-            raise_from(DatabaseError(*e.args), e)
-        else:
-            return response.get('QueryExecutionId', None)
+        query_id = self._find_previous_query_id(request, work_group, cache_size)
+        if query_id is None:
+            try:
+                query_id = retry_api_call(self._connection.client.start_query_execution,
+                                          config=self._retry_config,
+                                          logger=_logger,
+                                          **request).get('QueryExecutionId', None)
+            except Exception as e:
+                _logger.exception('Failed to execute query.')
+                raise_from(DatabaseError(*e.args), e)
+        return query_id
 
     @abstractmethod
-    def execute(self, operation, parameters=None, work_group=None, s3_staging_dir=None):
+    def execute(self, operation, parameters=None, work_group=None, s3_staging_dir=None,
+                cache_size=0):
         raise NotImplementedError  # pragma: no cover
 
     @abstractmethod

--- a/pyathena/common.py
+++ b/pyathena/common.py
@@ -144,7 +144,6 @@ class BaseCursor(with_metaclass(ABCMeta, object)):
 
     def _find_previous_query_id(self, request, work_group, cache_size):
         next_token = None
-        requested_location = request['ResultConfiguration']['OutputLocation']
         while cache_size > 0:
             n = min(cache_size, 50)  # 50 is max allowed by AWS API
             cache_size -= n
@@ -162,11 +161,8 @@ class BaseCursor(with_metaclass(ABCMeta, object)):
             for execution in query_executions:
                 queries_match = execution['Query'] == request['QueryString']
                 succeeded = execution['Status']['State'] == 'SUCCEEDED'
-                executed_location = execution['ResultConfiguration']['OutputLocation']
-                locations_match = executed_location == requested_location
                 is_dml = execution['StatementType'] == 'DML'
-                print(queries_match, succeeded, locations_match, is_dml)
-                if queries_match and succeeded and locations_match and is_dml:
+                if queries_match and succeeded and is_dml:
                     return execution['QueryExecutionId']
 
     def _execute(self, operation, parameters=None, work_group=None, s3_staging_dir=None,

--- a/pyathena/cursor.py
+++ b/pyathena/cursor.py
@@ -40,12 +40,14 @@ class Cursor(BaseCursor, CursorIterator, WithResultSet):
             self._result_set.close()
 
     @synchronized
-    def execute(self, operation, parameters=None, work_group=None, s3_staging_dir=None):
+    def execute(self, operation, parameters=None, work_group=None, s3_staging_dir=None,
+                cache_size=0):
         self._reset_state()
         self._query_id = self._execute(operation,
                                        parameters=parameters,
                                        work_group=work_group,
-                                       s3_staging_dir=s3_staging_dir)
+                                       s3_staging_dir=s3_staging_dir,
+                                       cache_size=cache_size)
         query_execution = self._poll(self._query_id)
         if query_execution.state == AthenaQueryExecution.STATE_SUCCEEDED:
             self._result_set = AthenaResultSet(

--- a/pyathena/pandas_cursor.py
+++ b/pyathena/pandas_cursor.py
@@ -42,12 +42,14 @@ class PandasCursor(BaseCursor, CursorIterator, WithResultSet):
             self._result_set.close()
 
     @synchronized
-    def execute(self, operation, parameters=None, work_group=None, s3_staging_dir=None):
+    def execute(self, operation, parameters=None, work_group=None, s3_staging_dir=None,
+                cache_size=0):
         self._reset_state()
         self._query_id = self._execute(operation,
                                        parameters=parameters,
                                        work_group=work_group,
-                                       s3_staging_dir=s3_staging_dir)
+                                       s3_staging_dir=s3_staging_dir,
+                                       cache_size=cache_size)
         query_execution = self._poll(self._query_id)
         if query_execution.state == AthenaQueryExecution.STATE_SUCCEEDED:
             self._result_set = AthenaPandasResultSet(

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -72,6 +72,29 @@ class TestCursor(unittest.TestCase):
         self.assertRaises(StopIteration, cursor.__next__)
 
     @with_cursor
+    def test_cache_size(self, cursor):
+        # To test cacheing, we need to make sure the query is unique, otherwise
+        # we might accidentally pick up the cache results from another CI run.
+        uniq_comment = "-- " + str(datetime.utcnow())
+
+        cursor.execute('SELECT * FROM one_row ' + uniq_comment)
+        cursor.fetchall()
+        first_query_id = cursor.query_id
+
+        cursor.execute('SELECT * FROM one_row ' + uniq_comment)
+        cursor.fetchall()
+        second_query_id = cursor.query_id
+        # Make sure default behavior is no cacheing, i.e. same query has
+        # run twice results in different query IDs
+        self.assertNotEqual(first_query_id, second_query_id)
+
+        cursor.execute('SELECT * FROM one_row ' + uniq_comment, cache_size=100)
+        cursor.fetchall()
+        third_query_id = cursor.query_id
+        # When using cacheing, the same query ID should be returned.
+        assert third_query_id in [first_query_id, second_query_id]
+
+    @with_cursor
     def test_arraysize(self, cursor):
         cursor.arraysize = 5
         cursor.execute('SELECT * FROM many_rows LIMIT 20')

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -75,20 +75,20 @@ class TestCursor(unittest.TestCase):
     def test_cache_size(self, cursor):
         # To test cacheing, we need to make sure the query is unique, otherwise
         # we might accidentally pick up the cache results from another CI run.
-        uniq_comment = "-- " + str(datetime.utcnow())
+        query = 'SELECT * FROM one_row -- {0}'.format(str(datetime.utcnow()))
 
-        cursor.execute('SELECT * FROM one_row ' + uniq_comment)
+        cursor.execute(query)
         cursor.fetchall()
         first_query_id = cursor.query_id
 
-        cursor.execute('SELECT * FROM one_row ' + uniq_comment)
+        cursor.execute(query)
         cursor.fetchall()
         second_query_id = cursor.query_id
         # Make sure default behavior is no cacheing, i.e. same query has
         # run twice results in different query IDs
         self.assertNotEqual(first_query_id, second_query_id)
 
-        cursor.execute('SELECT * FROM one_row ' + uniq_comment, cache_size=100)
+        cursor.execute(query, cache_size=100)
         cursor.fetchall()
         third_query_id = cursor.query_id
         # When using cacheing, the same query ID should be returned.


### PR DESCRIPTION
Add functionality that checks to see if the given query has been executed recently, and if so uses the results from that query (which Athena conveniently stores in S3). By default, this behavior is turned off to match the current behavior.

A new parameter `cache_size` is added to the `execute` method of `BaseCursor` subclasses. Only the previous `cache_size` queries are checked to see if they are a match.

A previously executed query is a "match" if it satisfies all of the following conditions:

* query strings match exactly
* the previous query succeeded
* previous query was a "DML" statement (so e.g. a CREATE TABLE statement will never be considered a "match")