### PR TITLE
Fix invalid requests when only workgroups are specified

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -755,7 +755,7 @@ Depends on the following environment variables:
     $ export AWS_DEFAULT_REGION=us-west-2
     $ export AWS_ATHENA_S3_STAGING_DIR=s3://YOUR_S3_BUCKET/path/to/
 
-And you need to create a workgroup named ``test-pyathena``.
+And you need to create a workgroup named ``test-pyathena`` with the ``Query result location`` configuration.
 
 Run test
 ~~~~~~~~

--- a/pyathena/common.py
+++ b/pyathena/common.py
@@ -114,17 +114,17 @@ class BaseCursor(with_metaclass(ABCMeta, object)):
                 time.sleep(self._poll_interval)
 
     def _build_start_query_execution_request(self, query, work_group=None, s3_staging_dir=None):
-        if not s3_staging_dir:
-            s3_staging_dir = self._s3_staging_dir
         request = {
             'QueryString': query,
             'QueryExecutionContext': {
                 'Database': self._schema_name,
             },
-            'ResultConfiguration': {
-                'OutputLocation': s3_staging_dir,
-            },
+            'ResultConfiguration': {}
         }
+        if self._s3_staging_dir or s3_staging_dir:
+            request['ResultConfiguration'].update({
+                'OutputLocation': s3_staging_dir if s3_staging_dir else self._s3_staging_dir
+            })
         if self._work_group or work_group:
             request.update({
                 'WorkGroup': work_group if work_group else self._work_group

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -442,9 +442,9 @@ class TestCursor(unittest.TestCase, WithConnect):
         cursor.execute('SELECT * FROM one_row')
         self.assertEqual(cursor.work_group, WORK_GROUP)
 
-    def test_no_s3_staging_dir(self):
-        conn = self.connect()
-        cursor = conn.cursor(s3_staging_dir=None, work_group=WORK_GROUP)
+    @with_cursor(work_group=WORK_GROUP)
+    def test_no_s3_staging_dir(self, cursor):
+        cursor._s3_staging_dir = None
         cursor.execute('SELECT * FROM one_row')
         self.assertNotEqual(cursor.output_location, None)
 

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -442,6 +442,12 @@ class TestCursor(unittest.TestCase, WithConnect):
         cursor.execute('SELECT * FROM one_row')
         self.assertEqual(cursor.work_group, WORK_GROUP)
 
+    def test_no_s3_staging_dir(self):
+        conn = self.connect()
+        cursor = conn.cursor(s3_staging_dir=None, work_group=WORK_GROUP)
+        cursor.execute('SELECT * FROM one_row')
+        self.assertNotEqual(cursor.output_location, None)
+
     @with_cursor()
     def test_executemany(self, cursor):
         cursor.executemany(


### PR DESCRIPTION
Thank you for developing such a useful library.

Fix exception raised when sending a request that specifies a workgroup and omits s3_staging_dir.

```python
>>> from pyathena import connect
>>> cursor = connect(work_group='test-pyathena').cursor()
>>> cursor.execute('SELECT 1')

Failed to execute query.
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/pyathena/common.py", line 206, in _execute
    **request).get('QueryExecutionId', None)
  File "/usr/local/lib/python3.7/site-packages/pyathena/util.py", line 214, in retry_api_call
    return retry(func, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/tenacity/__init__.py", line 330, in call
    start_time=start_time)
  File "/usr/local/lib/python3.7/site-packages/tenacity/__init__.py", line 279, in iter
    return fut.result()
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/concurrent/futures/_base.py", line 428, in result
    return self.__get_result()
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
  File "/usr/local/lib/python3.7/site-packages/tenacity/__init__.py", line 333, in call
    result = fn(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 316, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 599, in _make_api_call
    api_params, operation_model, context=request_context)
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 647, in _convert_to_request_dict
    api_params, operation_model)
  File "/usr/local/lib/python3.7/site-packages/botocore/validate.py", line 297, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter ResultConfiguration.OutputLocation, value: None, type: <class 'NoneType'>, valid types: <class 'str'>
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/pyathena/common.py", line 206, in _execute
    **request).get('QueryExecutionId', None)
  File "/usr/local/lib/python3.7/site-packages/pyathena/util.py", line 214, in retry_api_call
    return retry(func, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/tenacity/__init__.py", line 330, in call
    start_time=start_time)
  File "/usr/local/lib/python3.7/site-packages/tenacity/__init__.py", line 279, in iter
    return fut.result()
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/concurrent/futures/_base.py", line 428, in result
    return self.__get_result()
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
  File "/usr/local/lib/python3.7/site-packages/tenacity/__init__.py", line 333, in call
    result = fn(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 316, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 599, in _make_api_call
    api_params, operation_model, context=request_context)
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 647, in _convert_to_request_dict
    api_params, operation_model)
  File "/usr/local/lib/python3.7/site-packages/botocore/validate.py", line 297, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter ResultConfiguration.OutputLocation, value: None, type: <class 'NoneType'>, valid types: <class 'str'>

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.7/site-packages/pyathena/util.py", line 185, in _wrapper
    return wrapped(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/pyathena/cursor.py", line 50, in execute
    cache_size=cache_size)
  File "/usr/local/lib/python3.7/site-packages/pyathena/common.py", line 209, in _execute
    raise_from(DatabaseError(*e.args), e)
  File "/usr/local/lib/python3.7/site-packages/future/utils/__init__.py", line 398, in raise_from
    exec(execstr, myglobals, mylocals)
  File "<string>", line 1, in <module>
pyathena.error.DatabaseError: Parameter validation failed:
Invalid type for parameter ResultConfiguration.OutputLocation, value: None, type: <class 'NoneType'>, valid types: <class 'str'>
```
