### PR TITLE
[pandas] - Support partitions with special chars table names

### DIFF
--- a/pyathena/pandas/util.py
+++ b/pyathena/pandas/util.py
@@ -252,7 +252,7 @@ def to_sql(
     _logger.info(ddl)
     cursor.execute(ddl)
     if partitions:
-        repair = "MSCK REPAIR TABLE {0}.{1}".format(schema, name)
+        repair = "MSCK REPAIR TABLE `{0}`.`{1}`".format(schema, name)
         _logger.info(repair)
         cursor.execute(repair)
 


### PR DESCRIPTION
current implementation doesn't support add partition (MSCK REPAIR TABLE) for table names / schema names that starts with number / underscore.

this simple change fix this bug