### PR TITLE
Add support for table and column comments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,8 +124,10 @@ Supported SQLAlchemy is 1.0.0 or higher and less than 2.0.0.
         region_name="us-west-2",
         schema_name="default",
         s3_staging_dir=quote_plus("s3://YOUR_S3_BUCKET/path/to/")))
-    many_rows = Table("many_rows", MetaData(bind=engine), autoload=True)
-    print(select([func.count("*")], from_obj=many_rows).scalar())
+    with engine.connect() as connection:
+        many_rows = Table("many_rows", MetaData(), autoload_with=connection)
+        result = connection.execute(select([func.count("*")], from_obj=many_rows))
+        print(result.scalar())
 
 The connection string has the following format:
 

--- a/pyathena/sqlalchemy_athena.py
+++ b/pyathena/sqlalchemy_athena.py
@@ -199,13 +199,12 @@ class AthenaDDLCompiler(DDLCompiler):
             comment += self._escape_comment(column.comment, self.dialect)
         return f"{colspec}{comment}"
 
-    def visit_create_table(self, create):
+    def visit_create_table(self, create, **kwargs):
         table = create.element
         preparer = self.preparer
 
         text = "\nCREATE EXTERNAL "
-        text += "TABLE " + preparer.format_table(table) + " "
-        text += "("
+        text += "TABLE " + preparer.format_table(table) + " ("
 
         separator = "\n"
         for create_column in create.columns:
@@ -242,8 +241,15 @@ class AthenaDDLCompiler(DDLCompiler):
             if hasattr(table, "bind") and table.bind
             else None
         )
+        text = ""
+
+        if table.comment:
+            text += (
+                "COMMENT " + self._escape_comment(table.comment, self.dialect) + "\n"
+            )
+
         # TODO Supports orc, avro, json, csv or tsv format
-        text = "STORED AS PARQUET\n"
+        text += "STORED AS PARQUET\n"
 
         if dialect_opts["location"]:
             location = dialect_opts["location"]

--- a/pyathena/sqlalchemy_athena.py
+++ b/pyathena/sqlalchemy_athena.py
@@ -4,6 +4,7 @@ import numbers
 import re
 from distutils.util import strtobool
 
+import botocore
 import tenacity
 from sqlalchemy import exc, schema, util
 from sqlalchemy.engine import Engine, reflection
@@ -393,6 +394,22 @@ class AthenaDialect(DefaultDialect):
         return [row.schema_name for row in connection.execute(query).fetchall()]
 
     @reflection.cache
+    def _get_table(self, connection, table_name, schema=None, **kw):
+        raw_connection = self._raw_connection(connection)
+        schema = schema if schema else raw_connection.schema_name
+        with raw_connection.connection.cursor() as cursor:
+            try:
+                return cursor._get_table_metadata(table_name, schema_name=schema)
+            except pyathena.error.OperationalError as exc:
+                cause = exc.__cause__
+                if (
+                    isinstance(cause, botocore.exceptions.ClientError)
+                    and cause.response["Error"]["Code"] == "MetadataException"
+                ):
+                    raise NoSuchTableError(table_name) from exc
+                raise
+
+    @reflection.cache
     def _get_tables(self, connection, schema=None, **kw):
         raw_connection = self._raw_connection(connection)
         schema = schema if schema else raw_connection.schema_name
@@ -417,6 +434,24 @@ class AthenaDialect(DefaultDialect):
     def get_view_names(self, connection, schema=None, **kw):
         tables = self._get_tables(connection, schema, **kw)
         return [t.name for t in tables if t.table_type == "VIRTUAL_VIEW"]
+
+    def get_table_comment(self, connection, table_name, schema=None, **kw):
+        metadata = self._get_table(connection, table_name, schema=schema, **kw)
+        return {"text": metadata.comment}
+
+    def get_table_options(self, connection, table_name, schema=None, **kw):
+        metadata = self._get_table(connection, table_name, schema=schema, **kw)
+
+        if "compressionType" in metadata.parameters:
+            compression = metadata.parameters["compressionType"]
+        elif "parquet.compression" in metadata.parameters:
+            compression = metadata._parameters["parquet.compression"]
+        else:
+            return None
+        return {
+            "awsathena_location": metadata.location,
+            "awsathena_compression": compression,
+        }
 
     def has_table(self, connection, table_name, schema=None, **kw):
         try:

--- a/tests/sql/create_table.sql
+++ b/tests/sql/create_table.sql
@@ -1,5 +1,5 @@
 DROP TABLE IF EXISTS {schema}.one_row;
-CREATE EXTERNAL TABLE IF NOT EXISTS {schema}.one_row (number_of_rows INT)
+CREATE EXTERNAL TABLE IF NOT EXISTS {schema}.one_row (number_of_rows INT COMMENT 'some comment')
 ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t' LINES TERMINATED BY '\n' STORED AS TEXTFILE
 LOCATION '{location_one_row}';
 

--- a/tests/sql/create_table.sql
+++ b/tests/sql/create_table.sql
@@ -1,5 +1,6 @@
 DROP TABLE IF EXISTS {schema}.one_row;
 CREATE EXTERNAL TABLE IF NOT EXISTS {schema}.one_row (number_of_rows INT COMMENT 'some comment')
+COMMENT 'table comment'
 ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t' LINES TERMINATED BY '\n' STORED AS TEXTFILE
 LOCATION '{location_one_row}';
 

--- a/tests/test_sqlalchemy_athena.py
+++ b/tests/test_sqlalchemy_athena.py
@@ -83,15 +83,17 @@ class TestSQLAlchemyAthena(unittest.TestCase):
 
     @with_engine()
     def test_reflect_table(self, engine, conn):
-        one_row = Table("one_row", MetaData(bind=engine), autoload=True)
+        one_row = Table("one_row", MetaData(bind=engine), autoload_with=conn)
         self.assertEqual(len(one_row.c), 1)
         self.assertIsNotNone(one_row.c.number_of_rows)
+        self.assertEqual(table.comment, "table comment")
 
     @with_engine()
     def test_reflect_table_with_schema(self, engine, conn):
-        one_row = Table("one_row", MetaData(bind=engine), schema=SCHEMA, autoload=True)
+        one_row = Table("one_row", MetaData(), schema=SCHEMA, autoload_with=conn)
         self.assertEqual(len(one_row.c), 1)
         self.assertIsNotNone(one_row.c.number_of_rows)
+        self.assertEqual(table.comment, "table comment")
 
     @with_engine()
     def test_reflect_table_include_columns(self, engine, conn):


### PR DESCRIPTION
As mentioned in the commit comments, beyond the support of comments, by doing this we all put in place the necessary introspection mechanism need for implementing table properties and storage formats other than parquet.
