### PR TITLE
Fix the syntax for combining the OFFSET and LIMIT clauses (fix #280)

### DIFF
--- a/pyathena/sqlalchemy_athena.py
+++ b/pyathena/sqlalchemy_athena.py
@@ -78,6 +78,14 @@ class AthenaStatementCompiler(SQLCompiler):
     def visit_char_length_func(self, fn, **kw):
         return "length{0}".format(self.function_argspec(fn, **kw))
 
+    def limit_clause(self, select, **kw):
+        text = ""
+        if select._offset_clause is not None:
+            text += " OFFSET " + self.process(select._offset_clause, **kw)
+        if select._limit_clause is not None:
+            text += "\n LIMIT " + self.process(select._limit_clause, **kw)
+        return text
+
 
 class AthenaTypeCompiler(GenericTypeCompiler):
     def visit_FLOAT(self, type_, **kw):

--- a/tests/test_sqlalchemy_athena.py
+++ b/tests/test_sqlalchemy_athena.py
@@ -272,6 +272,12 @@ class TestSQLAlchemyAthena(unittest.TestCase):
         self.assertIsInstance(one_row_complex.c.col_decimal.type, DECIMAL)
 
     @with_engine()
+    def test_select_offset_limit(self, engine, conn):
+        many_rows = Table("many_rows", MetaData(), autoload_with=conn)
+        rows = conn.execute(many_rows.select().offset(10).limit(5)).fetchall()
+        self.assertEqual(rows, [(i,) for i in range(10, 15)])
+
+    @with_engine()
     def test_reserved_words(self, engine, conn):
         """Presto uses double quotes, not backticks"""
         fake_table = Table(


### PR DESCRIPTION
Override the limit_clause method:
https://github.com/sqlalchemy/sqlalchemy/blob/20213fd1f27fea51015d753bf94c6f40674ae86f/lib/sqlalchemy/sql/compiler.py#L3743-L3751