### PR TITLE
Fix CAST from STRING to VARCHAR for string types with unspecified length in SQLAlchemy. (fix #298)

### DIFF
--- a/pyathena/sqlalchemy_athena.py
+++ b/pyathena/sqlalchemy_athena.py
@@ -69,9 +69,8 @@ class AthenaStatementCompiler(SQLCompiler):
             type_clause = "CHAR"
         else:
             type_clause = cast.typeclause._compiler_dispatch(self, **kwargs)
-        return "CAST(%s AS %s)" % (
-            cast.clause._compiler_dispatch(self, **kwargs),
-            type_clause,
+        return (
+            f"CAST({cast.clause._compiler_dispatch(self, **kwargs)} AS {type_clause})"
         )
 
     def limit_clause(self, select, **kw):
@@ -97,12 +96,9 @@ class AthenaTypeCompiler(GenericTypeCompiler):
         if type_.precision is None:
             return "DECIMAL"
         elif type_.scale is None:
-            return "DECIMAL(%(precision)s)" % {"precision": type_.precision}
+            return f"DECIMAL({type_.precision})"
         else:
-            return "DECIMAL(%(precision)s, %(scale)s)" % {
-                "precision": type_.precision,
-                "scale": type_.scale,
-            }
+            return f"DECIMAL({type_.precision}, {type_.scale})"
 
     def visit_INTEGER(self, type_, **kw):
         return "INTEGER"
@@ -123,7 +119,7 @@ class AthenaTypeCompiler(GenericTypeCompiler):
         return "DATE"
 
     def visit_TIME(self, type_, **kw):
-        raise exc.CompileError("Data type `{0}` is not supported".format(type_))
+        raise exc.CompileError(f"Data type `{type_}` is not supported")
 
     def visit_CLOB(self, type_, **kw):
         return self.visit_BINARY(type_, **kw)

--- a/tests/test_sqlalchemy_athena.py
+++ b/tests/test_sqlalchemy_athena.py
@@ -691,3 +691,24 @@ class TestSQLAlchemyAthena(unittest.TestCase):
         self.assertIsInstance(actual.c.col_text.type, types.String)
         self.assertNotIsInstance(actual.c.col_text.type, types.VARCHAR)
         self.assertIsNone(actual.c.col_text.type.length)
+
+    @with_engine()
+    def test_cast_as_varchar(self, engine, conn):
+        # varchar without length
+        one_row = Table("one_row", MetaData(schema=SCHEMA), autoload_with=conn)
+        actual = conn.execute(
+            sqlalchemy.select(
+                [expression.cast(one_row.c.number_of_rows, types.VARCHAR)],
+                from_obj=one_row,
+            )
+        ).scalar()
+        self.assertEqual(actual, "1")
+
+        # varchar with length
+        actual = conn.execute(
+            sqlalchemy.select(
+                [expression.cast(one_row.c.number_of_rows, types.VARCHAR(10))],
+                from_obj=one_row,
+            )
+        ).scalar()
+        self.assertEqual(actual, "1")


### PR DESCRIPTION
TODO:
- [x] Unit tests