### PR TITLE
Fix escape handling for insert statements containing single quotes

### DIFF
--- a/pyathena/formatter.py
+++ b/pyathena/formatter.py
@@ -162,8 +162,11 @@ class DefaultParameterFormatter(Formatter):
             raise ProgrammingError("Query is none or empty.")
         operation = operation.strip()
 
-        if operation.upper().startswith("SELECT") or operation.upper().startswith(
-            "WITH"
+        operation_upper = operation.upper()
+        if (
+            operation_upper.startswith("SELECT")
+            or operation_upper.startswith("WITH")
+            or operation_upper.startswith("INSERT")
         ):
             escaper = _escape_presto
         else:

--- a/tests/pandas/test_cursor.py
+++ b/tests/pandas/test_cursor.py
@@ -374,12 +374,16 @@ class TestPandasCursor:
         assert rows == [(True, False), (False, None), (None, None)]
 
     def test_executemany(self, pandas_cursor):
+        rows = [(1, "foo"), (2, "bar"), (3, "jim o'rourke")]
         pandas_cursor.executemany(
-            "INSERT INTO execute_many_pandas (a) VALUES (%(a)s)",
-            [{"a": i} for i in range(1, 3)],
+            "INSERT INTO execute_many_pandas (a, b) VALUES (%(a)s, %(b)s)",
+            [
+                {"a": a, "b": b}
+                for a, b in [(1, "foo"), (2, "bar"), (3, "jim o'rourke")]
+            ],
         )
         pandas_cursor.execute("SELECT * FROM execute_many_pandas")
-        assert sorted(pandas_cursor.fetchall()) == [(i,) for i in range(1, 3)]
+        assert sorted(pandas_cursor.fetchall()) == [(a, b) for a, b in rows]
 
     def test_executemany_fetch(self, pandas_cursor):
         pandas_cursor.executemany(

--- a/tests/pandas/test_cursor.py
+++ b/tests/pandas/test_cursor.py
@@ -376,7 +376,7 @@ class TestPandasCursor:
     def test_executemany(self, pandas_cursor):
         rows = [(1, "foo"), (2, "bar"), (3, "jim o'rourke")]
         pandas_cursor.executemany(
-            "INSERT INTO execute_many_pandas (a, b) VALUES (%(a)s, %(b)s)",
+            "INSERT INTO execute_many_pandas (a, b) VALUES (%(a)d, %(b)s)",
             [
                 {"a": a, "b": b}
                 for a, b in [(1, "foo"), (2, "bar"), (3, "jim o'rourke")]

--- a/tests/resources/queries/create_table.sql.jinja2
+++ b/tests/resources/queries/create_table.sql.jinja2
@@ -61,14 +61,16 @@ LOCATION '{{ s3_staging_dir }}{{ schema }}/boolean_na_values/';
 
 DROP TABLE IF EXISTS {{ schema }}.execute_many;
 CREATE EXTERNAL TABLE IF NOT EXISTS {{ schema }}.execute_many (
-    a INT
+    a INT,
+    b STRING
 )
 ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t' LINES TERMINATED BY '\n' STORED AS TEXTFILE
 LOCATION '{{ s3_staging_dir }}{{ schema }}/execute_many/';
 
 DROP TABLE IF EXISTS {{ schema }}.execute_many_pandas;
 CREATE EXTERNAL TABLE IF NOT EXISTS {{ schema }}.execute_many_pandas (
-    a INT
+    a INT,
+    b STRING
 )
 ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t' LINES TERMINATED BY '\n' STORED AS TEXTFILE
 LOCATION '{{ s3_staging_dir }}{{ schema }}/execute_many_pandas/';

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -545,7 +545,7 @@ class TestCursor:
     def test_executemany(self, cursor):
         rows = [(1, "foo"), (2, "bar"), (3, "jim o'rourke")]
         cursor.executemany(
-            "INSERT INTO execute_many (a, b) VALUES (%(a)s, %(b)s)",
+            "INSERT INTO execute_many (a, b) VALUES (%(a)d, %(b)s)",
             [{"a": a, "b": b} for a, b in rows],
         )
         cursor.execute("SELECT * FROM execute_many")

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -543,12 +543,13 @@ class TestCursor:
         assert cursor.output_location
 
     def test_executemany(self, cursor):
+        rows = [(1, "foo"), (2, "bar"), (3, "jim o'rourke")]
         cursor.executemany(
-            "INSERT INTO execute_many (a) VALUES (%(a)s)",
-            [{"a": i} for i in range(1, 3)],
+            "INSERT INTO execute_many (a, b) VALUES (%(a)s, %(b)s)",
+            [{"a": a, "b": b} for a, b in rows],
         )
         cursor.execute("SELECT * FROM execute_many")
-        assert sorted(cursor.fetchall()) == [(i,) for i in range(1, 3)]
+        assert sorted(cursor.fetchall()) == [(a, b) for a, b in rows]
 
     def test_executemany_fetch(self, cursor):
         cursor.executemany("SELECT %(x)d FROM one_row", [{"x": i} for i in range(1, 2)])


### PR DESCRIPTION
https://docs.aws.amazon.com/athena/latest/ug/select.html#select-escaping
As with the SELECT statement, it appears that the INSERT statement can be escaped by preceding a single quote with another single quote.