### PR TITLE
Adding user-agent-extra parameter to improve Log Analysis

### DIFF
--- a/pyathena/connection.py
+++ b/pyathena/connection.py
@@ -141,7 +141,9 @@ class Connection:
 
         self.config: Optional[config.Config] = config
         self.config.user_agent_extra = (
-            "PyAthena/" + pyathena.__version__ + " " + str(config.user_agent_extra or "")
+            "PyAthena/"
+            + pyathena.__version__
+            + (" " + config.user_agent_extra if config.user_agent_extra else "")
         )
         self._client = self._session.client(
             "athena", region_name=self.region_name, config=self.config, **self._client_kwargs

--- a/pyathena/connection.py
+++ b/pyathena/connection.py
@@ -5,7 +5,7 @@ import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
 
 from boto3.session import Session
-from botocore import config
+from botocore.config import Config
 
 import pyathena
 from pyathena.common import BaseCursor
@@ -66,7 +66,7 @@ class Connection:
         cursor_kwargs: Optional[Dict[str, Any]] = None,
         kill_on_interrupt: bool = True,
         session: Optional[Session] = None,
-        config: Optional[config.Config] = config.Config(),
+        config: Optional[Config] = None,
         **kwargs,
     ) -> None:
         self._kwargs = {
@@ -139,11 +139,10 @@ class Connection:
                 **self._session_kwargs,
             )
 
-        self.config: Optional[config.Config] = config
+        self.config: Optional[Config] = config if config else Config()
         self.config.user_agent_extra = (
-            "PyAthena/"
-            + pyathena.__version__
-            + (" " + config.user_agent_extra if config.user_agent_extra else "")
+            f"PyAthena/{pyathena.__version__}"
+            f"{' ' + self.config.user_agent_extra if self.config.user_agent_extra else ''}"
         )
         self._client = self._session.client(
             "athena", region_name=self.region_name, config=self.config, **self._client_kwargs

--- a/pyathena/connection.py
+++ b/pyathena/connection.py
@@ -140,7 +140,9 @@ class Connection:
             )
 
         self.config: Optional[config.Config] = config
-        self.config.user_agent_extra = "PyAthena/" + pyathena.__version__ + " " + str(config.user_agent_extra or '')
+        self.config.user_agent_extra = (
+            "PyAthena/" + pyathena.__version__ + " " + str(config.user_agent_extra or "")
+        )
         self._client = self._session.client(
             "athena", region_name=self.region_name, config=self.config, **self._client_kwargs
         )
@@ -164,7 +166,9 @@ class Connection:
         session = Session(
             region_name=region_name, profile_name=profile_name, **self._session_kwargs
         )
-        client = session.client("sts", region_name=region_name, config=self.config, **self._client_kwargs)
+        client = session.client(
+            "sts", region_name=region_name, config=self.config, **self._client_kwargs
+        )
         request = {
             "RoleArn": role_arn,
             "RoleSessionName": role_session_name,
@@ -196,7 +200,9 @@ class Connection:
         duration_seconds: int,
     ) -> Dict[str, Any]:
         session = Session(profile_name=profile_name, **self._session_kwargs)
-        client = session.client("sts", region_name=region_name, config=self.config, **self._client_kwargs)
+        client = session.client(
+            "sts", region_name=region_name, config=self.config, **self._client_kwargs
+        )
         token_code = input("Enter the MFA code: ")
         request = {
             "DurationSeconds": duration_seconds,


### PR DESCRIPTION
User-agent is key parameter to improve Log Analysis. Previously, PyAthena users and tools developed using PyAthena were not able to differentiate boto3 calls from their calls. 

Introducing the user-agent-extra parameter to the PyAthena/boto3 connections allow users to identify HTTP calls from PyAthena and tools developed using PyAthena

Example of new user-agent:
`'User-Agent': b'Boto3/1.24.59 Python/3.7.10 Linux/4.14.296-222.539.amzn2.x86_64 Botocore/1.27.59 PyAthena/2.15.0 dbt-athena-community/1.3.2'`