### PR TITLE
Fix issue when installing version 2.18.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ sqlalchemy = {version = "<2.0.0,>=1.0.0", optional = true}
 pandas = {version = ">=1.3.0", optional = true}
 pyarrow = {version = ">=7.0.0", optional = true}
 fastparquet = {version = ">=0.4.0", optional = true}
-fsspec = {version = "*", optional = true}
+fsspec = {version = "*"}
 
 [tool.poetry.dev-dependencies]
 tox = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,10 +61,10 @@ pytest-cov = "*"
 pytest-xdist = "*"
 
 [tool.poetry.extras]
-pandas = ["pandas", "fsspec"]
+pandas = ["pandas"]
 sqlalchemy = ["sqlalchemy"]
 arrow = ["pyarrow"]
-fastparquet = ["fastparquet", "fsspec"]
+fastparquet = ["fastparquet"]
 
 [tool.poetry.plugins."sqlalchemy.dialects"]
 "awsathena" = "pyathena.sqlalchemy_athena:AthenaDialect"


### PR DESCRIPTION
Because 'fsspec' is marked as optional using the pyAthena library fails because it is imported in `pyathena/pandas/__init__.py`

```
  File "/usr/local/lib/python3.8/dist-packages/pyathena/pandas/__init__.py", line 2, in <module>"
    import fsspec"
ModuleNotFoundError: No module named 'fsspec'
```