### PR TITLE
reduce byte range by 1 to meet fsspec expectation

### DIFF
--- a/pyathena/filesystem/s3.py
+++ b/pyathena/filesystem/s3.py
@@ -379,7 +379,7 @@ class S3FileSystem(AbstractFileSystem):
         version_id: Optional[str] = None,
         kwargs: Optional[Dict[Any, Any]] = None,
     ) -> Tuple[int, bytes]:
-        range_ = f"bytes={ranges[0]}-{ranges[1]}"
+        range_ = f"bytes={ranges[0]}-{ranges[1] - 1}"
         request = {"Bucket": bucket, "Key": key, "Range": range_}
         if version_id:
             request.update({"versionId": version_id})

--- a/tests/filesystem/test_s3.py
+++ b/tests/filesystem/test_s3.py
@@ -1,10 +1,18 @@
 # -*- coding: utf-8 -*-
+from io import BytesIO
+
+import boto3
 import pytest
 
 from pyathena.filesystem.s3 import S3FileSystem
+from tests import ENV
+from tests.conftest import connect
 
 
 class TestS3FileSystem:
+
+    s3_test_file_key = ENV.s3_staging_key + "/S3FileSystem__test_read.dat"
+
     def test_parse_path(self):
         actual = S3FileSystem.parse_path("s3://bucket")
         assert actual[0] == "bucket"
@@ -102,3 +110,31 @@ class TestS3FileSystem:
 
         with pytest.raises(ValueError):
             S3FileSystem.parse_path("s3a://bucket/path/to/obj?foo=bar")
+
+    @pytest.fixture(scope="class")
+    def fs(self):
+        client = boto3.client("s3")
+        client.upload_fileobj(
+            BytesIO(b"0123456789"),
+            ENV.s3_staging_bucket,
+            self.s3_test_file_key,
+        )
+        fs = S3FileSystem(connect())
+        return fs
+
+    @pytest.mark.parametrize(
+        ["start", "end", "target_data"],
+        [(0, 5, b"01234"), (2, 7, b"23456")],
+    )
+    def test_read(self, fs, start, end, target_data):
+        # lowest level access: use _get_object
+        data = fs._get_object(ENV.s3_staging_bucket, self.s3_test_file_key, ranges=(start, end))
+        assert data == (start, target_data), data
+        with fs.open(f"s3://{ENV.s3_staging_bucket}/{self.s3_test_file_key}", "rb") as file:
+            # mid-level access: use _fetch_range
+            data = file._fetch_range(start, end)
+            assert data == target_data, data
+            # high-level: use fileobj seek and read
+            file.seek(start)
+            data = file.read(end - start)
+            assert data == target_data, data


### PR DESCRIPTION
Fix for https://github.com/laughingman7743/PyAthena/issues/399

Sets the byte range definition now in line with `s3fs` (compare https://github.com/fsspec/s3fs/blob/9b6f8c0eed2fb83217ac74c469250a0cf3d45f3c/s3fs/core.py#L2294), following expected behaviour by `fsspec`.