### PR TITLE
Removing filter that required tables to be explicitly external

### DIFF
--- a/pyathena/sqlalchemy_athena.py
+++ b/pyathena/sqlalchemy_athena.py
@@ -888,8 +888,11 @@ class AthenaDialect(DefaultDialect):
         return [s.name for s in schemas]
 
     def get_table_names(self, connection, schema=None, **kw):
+        # Tables created by Athena are always classified as `EXTERNAL_TABLE`, but Athena can also query tables
+        # classified as `MANAGED_TABLE`. Managed Tables are created by default when creating tables via Spark when
+        # Glue has been enabled as the Hive Metastore for Elastic Map Reduce (EMR) clusters.
         tables = self._get_tables(connection, schema, **kw)
-        return [t.name for t in tables]
+        return [t.name for t in tables if t.table_type in ["EXTERNAL_TABLE", "MANAGED_TABLE"]]
 
     def get_view_names(self, connection, schema=None, **kw):
         tables = self._get_tables(connection, schema, **kw)

--- a/pyathena/sqlalchemy_athena.py
+++ b/pyathena/sqlalchemy_athena.py
@@ -889,9 +889,7 @@ class AthenaDialect(DefaultDialect):
 
     def get_table_names(self, connection, schema=None, **kw):
         tables = self._get_tables(connection, schema, **kw)
-        # In Athena, only EXTERNAL_TABLE is supported.
-        # https://docs.aws.amazon.com/athena/latest/APIReference/API_TableMetadata.html
-        return [t.name for t in tables if t.table_type == "EXTERNAL_TABLE"]
+        return [t.name for t in tables]
 
     def get_view_names(self, connection, schema=None, **kw):
         tables = self._get_tables(connection, schema, **kw)


### PR DESCRIPTION
I don't have easy access to an AWS account for running the tests, but Im happy to make changes or update test if you can provide me with feedback.