### PR TITLE
Add EXTERNAL table type supported by Athena federation to the filter

### DIFF
--- a/pyathena/sqlalchemy_athena.py
+++ b/pyathena/sqlalchemy_athena.py
@@ -890,8 +890,10 @@ class AthenaDialect(DefaultDialect):
         # but Athena can also query tables classified as `MANAGED_TABLE`.
         # Managed Tables are created by default when creating tables via Spark when
         # Glue has been enabled as the Hive Metastore for Elastic Map Reduce (EMR) clusters.
+        # With Athena Federation, tables in the database that are connected to Athena via lambda function, 
+        # is classified as `EXTERNAL` and fully queryable 
         tables = self._get_tables(connection, schema, **kw)
-        return [t.name for t in tables if t.table_type in ["EXTERNAL_TABLE", "MANAGED_TABLE"]]
+        return [t.name for t in tables if t.table_type in ["EXTERNAL_TABLE", "MANAGED_TABLE", "EXTERNAL"]]
 
     def get_view_names(self, connection, schema=None, **kw):
         tables = self._get_tables(connection, schema, **kw)


### PR DESCRIPTION
In Athena federation query, there is a new Table Type **EXTERNAL**. The fix from this PR https://github.com/laughingman7743/PyAthena/pull/403 in PyAthena only supports **EXTERNAL_TABLE** and **MANAGED_TABLE**, which is created via Spark when Glue is enabled as hivemeta store, though EXTERNAL tables are fully queryable in Athena.