### PR TITLE
Fix FutureWarning: The argument 'infer_datetime_format' is deprecated…

### DIFF
--- a/pyathena/pandas/result_set.py
+++ b/pyathena/pandas/result_set.py
@@ -278,7 +278,6 @@ class AthenaPandasResultSet(AthenaResultSet):
                 dtype=self.dtypes,
                 converters=self.converters,
                 parse_dates=self.parse_dates,
-                infer_datetime_format=True,
                 skip_blank_lines=False,
                 keep_default_na=self._keep_default_na,
                 na_values=self._na_values,


### PR DESCRIPTION
… and will be removed in a future version. A strict version of it is now the default, see https://pandas.pydata.org/pdeps/0004-consistent-to-datetime-parsing.html. You can safely remove this argument.