### PR TITLE
Support rowcount field for Cursor Objects

### DIFF
--- a/pyathena/common.py
+++ b/pyathena/common.py
@@ -31,6 +31,7 @@ class CursorIterator(metaclass=ABCMeta):
         super(CursorIterator, self).__init__()
         self.arraysize: int = kwargs.get("arraysize", self.DEFAULT_FETCH_SIZE)
         self._rownumber: Optional[int] = None
+        self._rowcount: int = -1  # By default, return -1 to indicate that this is not supported.
 
     @property
     def arraysize(self) -> int:
@@ -50,8 +51,7 @@ class CursorIterator(metaclass=ABCMeta):
 
     @property
     def rowcount(self) -> int:
-        """By default, return -1 to indicate that this is not supported."""
-        return -1
+        return self._rowcount
 
     @abstractmethod
     def fetchone(self):

--- a/pyathena/cursor.py
+++ b/pyathena/cursor.py
@@ -78,6 +78,10 @@ class Cursor(BaseCursor, CursorIterator, WithResultSet):
     def rownumber(self) -> Optional[int]:
         return self.result_set.rownumber if self.result_set else None
 
+    @property
+    def rowcount(self) -> int:
+        return self.result_set.rowcount if self.result_set else -1
+
     def close(self) -> None:
         if self.result_set and not self.result_set.is_closed:
             self.result_set.close()


### PR DESCRIPTION
On ICEBERG table, GetQueryResults API returns UpdateCount field[1] for DML queries except SELECT.
So it should be available via `.rowcount` attribute in Cursor Objects[2].

In this PR, I've implemented `.rowcount` attribute for INSERT/UPDATE/DELETE/MERGE/CREATE_TABLE_AS_SELECT queries.

Well, `.rowcount` should be the number of rows for SELECT query but AWS Athena doesn't return row count for SELECT query so I've keep not supported yet for SELECT query.

* [1] https://docs.aws.amazon.com/athena/latest/APIReference/API_GetQueryResults.html#athena-GetQueryResults-response-UpdateCount
* [2] https://peps.python.org/pep-0249/#rowcount