### PR TITLE
Delay type annotation eval for compatibility with SQLAlchemy 1.4

### DIFF
--- a/pyathena/__init__.py
+++ b/pyathena/__init__.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import datetime
 from typing import TYPE_CHECKING, FrozenSet, Type
 

--- a/pyathena/arrow/async_cursor.py
+++ b/pyathena/arrow/async_cursor.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import logging
 from concurrent.futures import Future
 from multiprocessing import cpu_count

--- a/pyathena/arrow/converter.py
+++ b/pyathena/arrow/converter.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import logging
 from builtins import isinstance
 from copy import deepcopy

--- a/pyathena/arrow/result_set.py
+++ b/pyathena/arrow/result_set.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import logging
 from typing import (
     TYPE_CHECKING,

--- a/pyathena/arrow/util.py
+++ b/pyathena/arrow/util.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Dict, Tuple, cast
 
 if TYPE_CHECKING:

--- a/pyathena/async_cursor.py
+++ b/pyathena/async_cursor.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import logging
 from concurrent.futures import Future
 from concurrent.futures.thread import ThreadPoolExecutor

--- a/pyathena/common.py
+++ b/pyathena/common.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import logging
 import sys
 import time

--- a/pyathena/connection.py
+++ b/pyathena/connection.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import logging
 import os
 import time

--- a/pyathena/converter.py
+++ b/pyathena/converter.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import binascii
 import json
 import logging

--- a/pyathena/fastparquet/util.py
+++ b/pyathena/fastparquet/util.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Dict, Tuple
 
 if TYPE_CHECKING:

--- a/pyathena/filesystem/s3.py
+++ b/pyathena/filesystem/s3.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import itertools
 import logging
 import re

--- a/pyathena/filesystem/s3_object.py
+++ b/pyathena/filesystem/s3_object.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import logging
 from dataclasses import dataclass
 from typing import Any, Dict, Optional

--- a/pyathena/model.py
+++ b/pyathena/model.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import logging
 import re
 from datetime import datetime

--- a/pyathena/pandas/async_cursor.py
+++ b/pyathena/pandas/async_cursor.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import logging
 from concurrent.futures import Future
 from multiprocessing import cpu_count

--- a/pyathena/pandas/converter.py
+++ b/pyathena/pandas/converter.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import logging
 from copy import deepcopy
 from typing import Any, Callable, Dict, Optional, Type

--- a/pyathena/pandas/result_set.py
+++ b/pyathena/pandas/result_set.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import logging
 from collections import abc
 from multiprocessing import cpu_count

--- a/pyathena/pandas/util.py
+++ b/pyathena/pandas/util.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import concurrent
 import logging
 import textwrap

--- a/pyathena/result_set.py
+++ b/pyathena/result_set.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import collections
 import logging
 from abc import abstractmethod

--- a/pyathena/sqlalchemy/base.py
+++ b/pyathena/sqlalchemy/base.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import re
 from distutils.util import strtobool
 from typing import (

--- a/pyathena/sqlalchemy/types.py
+++ b/pyathena/sqlalchemy/types.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Any, Optional, Union
 

--- a/pyathena/util.py
+++ b/pyathena/util.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import logging
 import re
 from typing import Any, Callable, Iterable, Optional, Pattern, Tuple


### PR DESCRIPTION
This PR aims to address #445.

Due to the strange way SQLAlchemy wraps around PyAthena classes and functions, type hints are eagerly evaluated, which result in errors mentioned in the issue above. Adding `from __future__ import annotations` delays the evaluation of those type hints, which should not impact usage with IDE's and LSP's, but should allow newer versions of PyAthena to play nicely with SQLAlchemy 1.4.

Since `from __future__ import annotations` does not affect code evaluation and has already been use a few times elsewhere in the code base, this PR simply provides a blanket application of this state everywhere type hints are used. Please advise if we need to be more specific with applying this statement.

Thank you very much for considering this contribution.