### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
         run: poetry install --no-interaction --no-root
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-session-name: PyAthenaTestSession


### PR DESCRIPTION
https://github.com/laughingman7743/PyAthena/actions/runs/5384746821/jobs/9773026642#step:6:24
```
Please migrate your code to use AWS SDK for JavaScript (v3).
For more information, check the migration guide at https://a.co/7PzMCcy
(Use `node --trace-warnings ...` to show where the warning was created)
Error: OpenIDConnect provider's HTTPS certificate doesn't match configured thumbprint
```