### PR TITLE
Implemented ICEBERG partition & partition transform functions

### DIFF
--- a/pyathena/model.py
+++ b/pyathena/model.py
@@ -487,3 +487,23 @@ class AthenaCompression:
             AthenaCompression.COMPRESSION_ZLIB,
             AthenaCompression.COMPRESSION_ZSTD,
         ]
+
+
+class AthenaPartitionTransform:
+    PARTITION_TRANSFORM_YEAR: str = "year"
+    PARTITION_TRANSFORM_MONTH: str = "month"
+    PARTITION_TRANSFORM_DAY: str = "day"
+    PARTITION_TRANSFORM_HOUR: str = "hour"
+    PARTITION_TRANSFORM_BUCKET: str = "bucket"
+    PARTITION_TRANSFORM_TRUNCATE: str = "truncate"
+
+    @staticmethod
+    def is_valid(value: str) -> bool:
+        return value.lower() in [
+            AthenaPartitionTransform.PARTITION_TRANSFORM_YEAR,
+            AthenaPartitionTransform.PARTITION_TRANSFORM_MONTH,
+            AthenaPartitionTransform.PARTITION_TRANSFORM_DAY,
+            AthenaPartitionTransform.PARTITION_TRANSFORM_HOUR,
+            AthenaPartitionTransform.PARTITION_TRANSFORM_BUCKET,
+            AthenaPartitionTransform.PARTITION_TRANSFORM_TRUNCATE,
+        ]

--- a/tests/pyathena/sqlalchemy/test_base.py
+++ b/tests/pyathena/sqlalchemy/test_base.py
@@ -1269,6 +1269,52 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
         assert actual.c.col_partition_1.dialect_options["awsathena"]["partition"]
         assert actual.c.col_partition_2.dialect_options["awsathena"]["partition"]
 
+    def test_create_iceberg_table_with_partition(self, engine):
+            engine, conn = engine
+            table_name = "test_create_iceberg_table_with_partition"
+            table_comment = "table comment"
+            column_comment = "column comment"
+            table = Table(
+                table_name,
+                MetaData(schema=ENV.schema),
+                Column("col_1", types.String, comment=column_comment),
+                Column("col_partition_1", types.String, awsathena_partition=True, comment=column_comment),
+                Column("col_partition_2", types.Integer, awsathena_partition=True),
+                Column("col_2", types.Integer),
+                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+                comment=table_comment,
+                awsathena_tblproperties={"table_type": "ICEBERG"}
+            )
+            ddl = CreateTable(table).compile(bind=conn)
+            table.create(bind=conn)
+            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+
+            assert str(ddl) == textwrap.dedent(
+                f"""
+                CREATE TABLE {ENV.schema}.{table_name} (
+                \tcol_1 STRING COMMENT '{column_comment}',
+                \tcol_partition_1 STRING COMMENT 'column comment',
+                \tcol_partition_2 INT,
+                \tcol_2 INT
+                )
+                COMMENT '{table_comment}'
+                PARTITIONED BY (
+                \tcol_partition_1,
+                \tcol_partition_2
+                )
+                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+                TBLPROPERTIES (
+                \t'table_type' = 'ICEBERG'
+                )
+                """
+            )
+            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+            assert actual.c.col_partition_1.dialect_options["awsathena"]["partition"]
+            assert actual.c.col_partition_2.dialect_options["awsathena"]["partition"]
+            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+            assert tblproperties["table_type"] == "ICEBERG"
+
     def test_create_table_with_date_partition(self, engine):
         engine, conn = engine
         table_name = "test_create_table_with_date_partition"
@@ -1318,6 +1364,280 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
         assert tblproperties["projection.dt.type"] == "date"
         assert tblproperties["projection.dt.range"] == "NOW-1YEARS,NOW"
         assert tblproperties["projection.dt.format"] == "yyyy-MM-dd"
+
+    def test_create_iceberg_table_with_date_partition(self, engine):
+            engine, conn = engine
+            table_name = "test_create_iceberg_table_with_date_partition"
+            table = Table(
+                table_name,
+                MetaData(schema=ENV.schema),
+                Column("col_1", types.String),
+                Column("col_2", types.Integer),
+                Column("dt", types.Date, awsathena_partition=True),
+                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+                awsathena_tblproperties={"table_type": "ICEBERG"},
+            )
+            ddl = CreateTable(table).compile(bind=conn)
+            table.create(bind=conn)
+            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+
+            assert str(ddl) == textwrap.dedent(
+                f"""
+                CREATE TABLE {ENV.schema}.{table_name} (
+                \tcol_1 STRING,
+                \tcol_2 INT
+                \tdt DATE
+                )
+                PARTITIONED BY (
+                \tdt
+                )
+                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+                TBLPROPERTIES (
+                \t'table_type' = 'ICEBERG'
+                )
+                """
+            )
+            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+            assert actual.c.dt.dialect_options["awsathena"]["partition"]
+            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+            assert tblproperties["table_type"] == "ICEBERG"
+
+    def test_create_iceberg_table_with_year_partition_transform(self, engine):
+            engine, conn = engine
+            table_name = "test_create_iceberg_table_with_year_partition_transform"
+            table = Table(
+                table_name,
+                MetaData(schema=ENV.schema),
+                Column("col_1", types.String),
+                Column("col_2", types.Integer),
+                Column("dt", types.Date, awsathena_partition=True, awsathena_partition_transform='year'),
+                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+                awsathena_tblproperties={"table_type": "ICEBERG"},
+            )
+            ddl = CreateTable(table).compile(bind=conn)
+            table.create(bind=conn)
+            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+
+            assert str(ddl) == textwrap.dedent(
+                f"""
+                CREATE TABLE {ENV.schema}.{table_name} (
+                \tcol_1 STRING,
+                \tcol_2 INT
+                \tdt DATE
+                )
+                PARTITIONED BY (
+                \tyear(dt)
+                )
+                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+                TBLPROPERTIES (
+                \t'table_type' = 'ICEBERG'
+                )
+                """
+            )
+            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+            assert actual.c.dt.dialect_options["awsathena"]["partition"]
+            assert actual.c.dt.dialect_options["awsathena"]["partition_transform"] == 'year'
+            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+            assert tblproperties["table_type"] == "ICEBERG"
+
+    def test_create_iceberg_table_with_month_partition_transform(self, engine):
+            engine, conn = engine
+            table_name = "test_create_iceberg_table_with_month_partition_transform"
+            table = Table(
+                table_name,
+                MetaData(schema=ENV.schema),
+                Column("col_1", types.String),
+                Column("col_2", types.Integer),
+                Column("dt", types.Date, awsathena_partition=True, awsathena_partition_transform='month'),
+                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+                awsathena_tblproperties={"table_type": "ICEBERG"},
+            )
+            ddl = CreateTable(table).compile(bind=conn)
+            table.create(bind=conn)
+            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+
+            assert str(ddl) == textwrap.dedent(
+                f"""
+                CREATE TABLE {ENV.schema}.{table_name} (
+                \tcol_1 STRING,
+                \tcol_2 INT
+                \tdt DATE
+                )
+                PARTITIONED BY (
+                \tmonth(dt)
+                )
+                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+                TBLPROPERTIES (
+                \t'table_type' = 'ICEBERG'
+                )
+                """
+            )
+            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+            assert actual.c.dt.dialect_options["awsathena"]["partition"]
+            assert actual.c.dt.dialect_options["awsathena"]["partition_transform"] == 'month'
+            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+            assert tblproperties["table_type"] == "ICEBERG"
+
+    def test_create_iceberg_table_with_day_partition_transform(self, engine):
+            engine, conn = engine
+            table_name = "test_create_iceberg_table_with_day_partition_transform"
+            table = Table(
+                table_name,
+                MetaData(schema=ENV.schema),
+                Column("col_1", types.String),
+                Column("col_2", types.Integer),
+                Column("dt", types.Date, awsathena_partition=True, awsathena_partition_transform='day'),
+                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+                awsathena_tblproperties={"table_type": "ICEBERG"},
+            )
+            ddl = CreateTable(table).compile(bind=conn)
+            table.create(bind=conn)
+            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+
+            assert str(ddl) == textwrap.dedent(
+                f"""
+                CREATE TABLE {ENV.schema}.{table_name} (
+                \tcol_1 STRING,
+                \tcol_2 INT
+                \tdt DATE
+                )
+                PARTITIONED BY (
+                \tday(dt)
+                )
+                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+                TBLPROPERTIES (
+                \t'table_type' = 'ICEBERG'
+                )
+                """
+            )
+            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+            assert actual.c.dt.dialect_options["awsathena"]["partition"]
+            assert actual.c.dt.dialect_options["awsathena"]["partition_transform"] == 'day'
+            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+            assert tblproperties["table_type"] == "ICEBERG"
+
+    def test_create_iceberg_table_with_hour_partition_transform(self, engine):
+            engine, conn = engine
+            table_name = "test_create_iceberg_table_with_hour_partition_transform"
+            table = Table(
+                table_name,
+                MetaData(schema=ENV.schema),
+                Column("col_1", types.String),
+                Column("col_2", types.Integer),
+                Column("ts", types.TIMESTAMP, awsathena_partition=True, awsathena_partition_transform='hour'),
+                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+                awsathena_tblproperties={"table_type": "ICEBERG"},
+            )
+            ddl = CreateTable(table).compile(bind=conn)
+            table.create(bind=conn)
+            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+
+            assert str(ddl) == textwrap.dedent(
+                f"""
+                CREATE TABLE {ENV.schema}.{table_name} (
+                \tcol_1 STRING,
+                \tcol_2 INT
+                \tts TIMESTAMP
+                )
+                PARTITIONED BY (
+                \thour(ts)
+                )
+                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+                TBLPROPERTIES (
+                \t'table_type' = 'ICEBERG'
+                )
+                """
+            )
+            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+            assert actual.c.ts.dialect_options["awsathena"]["partition"]
+            assert actual.c.ts.dialect_options["awsathena"]["partition_transform"] == 'hour'
+            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+            assert tblproperties["table_type"] == "ICEBERG"
+
+    def test_create_iceberg_table_with_bucket_partition_transform(self, engine):
+            engine, conn = engine
+            table_name = "test_create_iceberg_table_with_bucket_partition_transform"
+            table = Table(
+                table_name,
+                MetaData(schema=ENV.schema),
+                Column("col_1", types.String),
+                Column("col_2", types.Integer),
+                Column("col_partition_bucket_1", types.Integer, awsathena_partition=True, awsathena_partition_transform='bucket', awsathena_partition_transform_bucket_count=5),
+                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+                awsathena_tblproperties={"table_type": "ICEBERG"},
+            )
+            ddl = CreateTable(table).compile(bind=conn)
+            table.create(bind=conn)
+            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+
+            assert str(ddl) == textwrap.dedent(
+                f"""
+                CREATE TABLE {ENV.schema}.{table_name} (
+                \tcol_1 STRING,
+                \tcol_2 INT
+                \tcol_partition_bucket_1 INT
+                )
+                PARTITIONED BY (
+                \tbucket(5, col_partition_bucket_1)
+                )
+                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+                TBLPROPERTIES (
+                \t'table_type' = 'ICEBERG'
+                )
+                """
+            )
+            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+            assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition"]
+            assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition_transform"] == 'bucket'
+            assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition_transform_bucket_count"] == 5
+            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+            assert tblproperties["table_type"] == "ICEBERG"
+
+    def test_create_iceberg_table_with_truncate_partition_transform(self, engine):
+            engine, conn = engine
+            table_name = "test_create_iceberg_table_with_truncate_partition_transform"
+            table = Table(
+                table_name,
+                MetaData(schema=ENV.schema),
+                Column("col_1", types.String),
+                Column("col_2", types.Integer),
+                Column("col_partition_truncate_1", types.String, awsathena_partition=True, awsathena_partition_transform='truncate', awsathena_partition_transform_truncate_length=5),
+                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+                awsathena_tblproperties={"table_type": "ICEBERG"},
+            )
+            ddl = CreateTable(table).compile(bind=conn)
+            table.create(bind=conn)
+            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+
+            assert str(ddl) == textwrap.dedent(
+                f"""
+                CREATE TABLE {ENV.schema}.{table_name} (
+                \tcol_1 STRING,
+                \tcol_2 INT
+                \tcol_partition_bucket_1 STRING
+                )
+                PARTITIONED BY (
+                \ttruncate(5, col_partition_truncate_1)
+                )
+                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+                TBLPROPERTIES (
+                \t'table_type' = 'ICEBERG'
+                )
+                """
+            )
+            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+            assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition"]
+            assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition_transform"] == 'truncate'
+            assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition_transform_truncate_length"] == 5
+            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+            assert tblproperties["table_type"] == "ICEBERG"
 
     def test_insert_from_select_cte_follows_insert_one(self, engine):
         engine, conn = engine

--- a/tests/pyathena/sqlalchemy/test_base.py
+++ b/tests/pyathena/sqlalchemy/test_base.py
@@ -1620,7 +1620,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
                 CREATE TABLE {ENV.schema}.{table_name} (
                 \tcol_1 STRING,
                 \tcol_2 INT
-                \tcol_partition_bucket_1 STRING
+                \tcol_partition_truncate_1
                 )
                 PARTITIONED BY (
                 \ttruncate(5, col_partition_truncate_1)
@@ -1633,9 +1633,9 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             )
             assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
             assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
-            assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition"]
-            assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition_transform"] == 'truncate'
-            assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition_transform_truncate_length"] == 5
+            assert actual.c.col_partition_truncate_1.dialect_options["awsathena"]["partition"]
+            assert actual.c.col_partition_truncate_1.dialect_options["awsathena"]["partition_transform"] == 'truncate'
+            assert actual.c.col_partition_truncate_1.dialect_options["awsathena"]["partition_transform_truncate_length"] == 5
             tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
             assert tblproperties["table_type"] == "ICEBERG"
 

--- a/tests/pyathena/test_model.py
+++ b/tests/pyathena/test_model.py
@@ -397,3 +397,20 @@ class TestAthenaCompression:
         assert AthenaCompression.is_valid("SNAPPY")
         assert not AthenaCompression.is_valid("")
         assert not AthenaCompression.is_valid("foobar")
+
+class TestAthenaPartitionTransform:
+    def test_is_valid(self):
+        assert AthenaCompression.is_valid("year")
+        assert AthenaCompression.is_valid("YEAR")
+        assert AthenaCompression.is_valid("month")
+        assert AthenaCompression.is_valid("MONTH")
+        assert AthenaCompression.is_valid("day")
+        assert AthenaCompression.is_valid("DAY")
+        assert AthenaCompression.is_valid("hour")
+        assert AthenaCompression.is_valid("HOUR")
+        assert AthenaCompression.is_valid("bucket")
+        assert AthenaCompression.is_valid("BUCKET")
+        assert AthenaCompression.is_valid("truncate")
+        assert AthenaCompression.is_valid("TRUNCATE")
+        assert not AthenaCompression.is_valid("")
+        assert not AthenaCompression.is_valid("foobar")


### PR DESCRIPTION
Solves #458 

I adapted the handling of the column dialect option 'partition' in _prepared_columns() for ICEBERG tables.
I also added three column dialect options. 
- "partition_transform" - pass partition transform function
- "partition_transform_bucket_count" - pass bucket count for partition transform function 'bucket'
- "partition_transform_truncate_length" - pass truncate length for partition transform function 'truncate'

All partition functions are defined in model.py under AthenaPartitionTransform.

I did not add handlers for the connect options for those column dialect options.
Also did not update the README.