### PR TITLE
Sqlalchemy iceberg partition

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -318,6 +318,53 @@ partition
         .. code:: python
 
             Column("some_column", types.String, ..., awsathena_partition=True)
+
+partition_transform
+    Type:
+        str
+    Description:
+        Specifies a partition transform function for partitioning data.
+        Only has an effect for ICEBERG tables and when partition is set to true for the column.
+    Value:
+        * year
+        * month
+        * day
+        * hour
+        * bucket
+        * truncate
+    Example:
+        .. code:: python
+
+            Column("some_column", types.Date, ..., awsathena_partition=True, awsathena_partition_transform='year')
+
+partition_transform_bucket_count
+    Type:
+        int
+    Description:
+        Used for N in the bucket partition transform function, partitions by hashed value mod N buckets.
+        Only has an effect for ICEBERG tables and when partition is set to true and
+        when the partition transform is set to 'bucket' for the column.
+    Value:
+        Integer value greater than or equal to 0
+    Example:
+        .. code:: python
+
+            Column("some_column", types.String, ..., awsathena_partition=True, awsathena_partition_transform='bucket', awsathena_partition_transform_bucket_count=5)
+
+partition_transform_truncate_length
+    Type:
+        int
+    Description:
+        Used for L in the truncate partition transform function, partitions by value truncated to L.
+        Only has an effect for ICEBERG tables and when partition is set to true and
+        when the partition transform is set to 'truncate' for the column.
+    Value:
+        Integer value greater than or equal to 0
+    Example:
+        .. code:: python
+
+            Column("some_column", types.String, ..., awsathena_partition=True, awsathena_partition_transform='truncate', awsathena_partition_transform_truncate_length=5)
+
 cluster
     Type:
         bool
@@ -331,6 +378,8 @@ cluster
             Column("some_column", types.String, ..., awsathena_cluster=True)
 
 To configure column options from the connection string, specify the column name as a comma-separated string.
+The options partition_transform, partition_transform_bucket_count, partition_transform_truncate_length are not supported
+to be configured from the connection string.
 
 .. code:: text
 

--- a/pyathena/model.py
+++ b/pyathena/model.py
@@ -487,3 +487,23 @@ class AthenaCompression:
             AthenaCompression.COMPRESSION_ZLIB,
             AthenaCompression.COMPRESSION_ZSTD,
         ]
+
+
+class AthenaPartitionTransform:
+    PARTITION_TRANSFORM_YEAR: str = "year"
+    PARTITION_TRANSFORM_MONTH: str = "month"
+    PARTITION_TRANSFORM_DAY: str = "day"
+    PARTITION_TRANSFORM_HOUR: str = "hour"
+    PARTITION_TRANSFORM_BUCKET: str = "bucket"
+    PARTITION_TRANSFORM_TRUNCATE: str = "truncate"
+
+    @staticmethod
+    def is_valid(value: str) -> bool:
+        return value.lower() in [
+            AthenaPartitionTransform.PARTITION_TRANSFORM_YEAR,
+            AthenaPartitionTransform.PARTITION_TRANSFORM_MONTH,
+            AthenaPartitionTransform.PARTITION_TRANSFORM_DAY,
+            AthenaPartitionTransform.PARTITION_TRANSFORM_HOUR,
+            AthenaPartitionTransform.PARTITION_TRANSFORM_BUCKET,
+            AthenaPartitionTransform.PARTITION_TRANSFORM_TRUNCATE,
+        ]

--- a/pyathena/sqlalchemy/base.py
+++ b/pyathena/sqlalchemy/base.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import re
+import textwrap
 from distutils.util import strtobool
 from typing import (
     TYPE_CHECKING,
@@ -807,13 +808,15 @@ class AthenaDDLCompiler(DDLCompiler):
                                         ]
                                         if bucket_count:
                                             partitions.append(
-                                                f"""
+                                                textwrap.dedent(
+                                                    f"""
                                                     \t
                                                     {partition_transform}(
                                                         {bucket_count},
                                                         {self.preparer.format_column(column)}
                                                     )
                                                 """
+                                                )
                                             )
                                     elif (
                                         partition_transform
@@ -824,22 +827,26 @@ class AthenaDDLCompiler(DDLCompiler):
                                         ]
                                         if truncate_length:
                                             partitions.append(
-                                                f"""
+                                                textwrap.dedent(
+                                                    f"""
                                                     \t
                                                     {partition_transform}(
                                                         {truncate_length},
                                                         {self.preparer.format_column(column)}
                                                     )
                                                 """
+                                                )
                                             )
                                     else:
                                         partitions.append(
-                                            f"""
+                                            textwrap.dedent(
+                                                f"""
                                                 \t
                                                 {partition_transform}(
                                                     {self.preparer.format_column(column)}
                                                 )
                                             """
+                                            )
                                         )
                             else:
                                 partitions.append(f"\t{self.preparer.format_column(column)}")

--- a/pyathena/sqlalchemy/base.py
+++ b/pyathena/sqlalchemy/base.py
@@ -799,11 +799,12 @@ class AthenaDDLCompiler(DDLCompiler):
                             if partition_transform:
                                 if AthenaPartitionTransform.is_valid(partition_transform):
                                     if (
-                                        partition_transform ==
-                                        AthenaPartitionTransform.PARTITION_TRANSFORM_BUCKET
+                                        partition_transform
+                                        == AthenaPartitionTransform.PARTITION_TRANSFORM_BUCKET
                                     ):
-                                        bucket_count = \
-                                            column_dialect_opts["partition_transform_bucket_count"]
+                                        bucket_count = column_dialect_opts[
+                                            "partition_transform_bucket_count"
+                                        ]
                                         if bucket_count:
                                             partitions.append(
                                                 f"""
@@ -815,13 +816,12 @@ class AthenaDDLCompiler(DDLCompiler):
                                                 """
                                             )
                                     elif (
-                                        partition_transform ==
-                                        AthenaPartitionTransform.PARTITION_TRANSFORM_TRUNCATE
+                                        partition_transform
+                                        == AthenaPartitionTransform.PARTITION_TRANSFORM_TRUNCATE
                                     ):
-                                        truncate_length = \
-                                            column_dialect_opts[
-                                                "partition_transform_truncate_length"
-                                            ]
+                                        truncate_length = column_dialect_opts[
+                                            "partition_transform_truncate_length"
+                                        ]
                                         if truncate_length:
                                             partitions.append(
                                                 f"""
@@ -886,10 +886,7 @@ class AthenaDDLCompiler(DDLCompiler):
         text = [" ".join(text)]
 
         columns, partitions, buckets = self._prepared_columns(
-            table,
-            is_iceberg,
-            create.columns,
-            connect_opts
+            table, is_iceberg, create.columns, connect_opts
         )
         text.append(",\n".join(columns))
         text.append(")")

--- a/pyathena/sqlalchemy/base.py
+++ b/pyathena/sqlalchemy/base.py
@@ -808,7 +808,7 @@ class AthenaDDLCompiler(DDLCompiler):
                                             "partition_transform_bucket_count"
                                         ]
                                         if bucket_count:
-                                            transform_column = {bucket_count}, {column_name}
+                                            transform_column = f"{bucket_count}, {column_name}"
                                     elif (
                                         partition_transform
                                         == AthenaPartitionTransform.PARTITION_TRANSFORM_TRUNCATE
@@ -817,7 +817,7 @@ class AthenaDDLCompiler(DDLCompiler):
                                             "partition_transform_truncate_length"
                                         ]
                                         if truncate_length:
-                                            transform_column = {truncate_length}, {column_name}
+                                            transform_column = f"{truncate_length}, {column_name}"
                                     else:
                                         transform_column = column_name
 

--- a/pyathena/sqlalchemy/base.py
+++ b/pyathena/sqlalchemy/base.py
@@ -33,7 +33,12 @@ from sqlalchemy.sql.compiler import (
 )
 
 import pyathena
-from pyathena.model import AthenaFileFormat, AthenaRowFormatSerde, AthenaPartitionTransform
+from pyathena.model import (
+    AthenaFileFormat,
+    AthenaRowFormatSerde,
+    AthenaPartitionTransform,
+)
+
 from pyathena.sqlalchemy.types import AthenaDate, AthenaTimestamp
 from pyathena.sqlalchemy.util import _HashableDict
 
@@ -789,17 +794,27 @@ class AthenaDDLCompiler(DDLCompiler):
                         or column.name in conn_partitions
                         or f"{table.name}.{column.name}" in conn_partitions
                     ):
-                        #https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg-creating-tables.html#querying-iceberg-partitioning
+                        # https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg-creating-tables.html#querying-iceberg-partitioning
                         if is_iceberg:
                             partition_transform = column_dialect_opts["partition_transform"]
                             if partition_transform:
                                 if AthenaPartitionTransform.is_valid(partition_transform):
-                                    if partition_transform == AthenaPartitionTransform.PARTITION_TRANSFORM_BUCKET:
-                                        bucket_count = column_dialect_opts["partition_transform_bucket_count"]
+                                    if (
+                                        partition_transform ==
+                                        AthenaPartitionTransform.PARTITION_TRANSFORM_BUCKET
+                                    ):
+                                        bucket_count = \
+                                            column_dialect_opts["partition_transform_bucket_count"]
                                         if bucket_count:
-                                            partitions.append(f"\t{partition_transform}({bucket_count},{self.preparer.format_column(column)})")
-                                    elif partition_transform == AthenaPartitionTransform.PARTITION_TRANSFORM_TRUNCATE:
-                                        truncate_length = column_dialect_opts["partition_transform_truncate_length"]
+                                            partitions.append(
+                                                f"\t{partition_transform}({bucket_count},{self.preparer.format_column(column)})"
+                                            )
+                                    elif (
+                                        partition_transform ==
+                                        AthenaPartitionTransform.PARTITION_TRANSFORM_TRUNCATE
+                                    ):
+                                        truncate_length = \
+                                            column_dialect_opts["partition_transform_truncate_length"]
                                         if truncate_length:
                                             partitions.append(f"\t{partition_transform}({truncate_length},{self.preparer.format_column(column)})")
                                     else:
@@ -848,7 +863,12 @@ class AthenaDDLCompiler(DDLCompiler):
         text.append("(")
         text = [" ".join(text)]
 
-        columns, partitions, buckets = self._prepared_columns(table, is_iceberg, create.columns, connect_opts)
+        columns, partitions, buckets = self._prepared_columns(
+            table,
+            is_iceberg,
+            create.columns,
+            connect_opts
+        )
         text.append(",\n".join(columns))
         text.append(")")
 

--- a/pyathena/sqlalchemy/base.py
+++ b/pyathena/sqlalchemy/base.py
@@ -807,18 +807,41 @@ class AthenaDDLCompiler(DDLCompiler):
                                             column_dialect_opts["partition_transform_bucket_count"]
                                         if bucket_count:
                                             partitions.append(
-                                                f"\t{partition_transform}({bucket_count},{self.preparer.format_column(column)})"
+                                                f"""
+                                                    \t
+                                                    {partition_transform}(
+                                                        {bucket_count},
+                                                        {self.preparer.format_column(column)}
+                                                    )
+                                                """
                                             )
                                     elif (
                                         partition_transform ==
                                         AthenaPartitionTransform.PARTITION_TRANSFORM_TRUNCATE
                                     ):
                                         truncate_length = \
-                                            column_dialect_opts["partition_transform_truncate_length"]
+                                            column_dialect_opts[
+                                                "partition_transform_truncate_length"
+                                            ]
                                         if truncate_length:
-                                            partitions.append(f"\t{partition_transform}({truncate_length},{self.preparer.format_column(column)})")
+                                            partitions.append(
+                                                f"""
+                                                    \t
+                                                    {partition_transform}(
+                                                        {truncate_length},
+                                                        {self.preparer.format_column(column)}
+                                                    )
+                                                """
+                                            )
                                     else:
-                                        partitions.append(f"\t{partition_transform}({self.preparer.format_column(column)})")
+                                        partitions.append(
+                                            f"""
+                                                \t
+                                                {partition_transform}(
+                                                    {self.preparer.format_column(column)}
+                                                )
+                                            """
+                                        )
                             else:
                                 partitions.append(f"\t{self.preparer.format_column(column)}")
                             columns.append(f"\t{processed}")

--- a/pyathena/sqlalchemy/base.py
+++ b/pyathena/sqlalchemy/base.py
@@ -35,10 +35,9 @@ from sqlalchemy.sql.compiler import (
 import pyathena
 from pyathena.model import (
     AthenaFileFormat,
-    AthenaRowFormatSerde,
     AthenaPartitionTransform,
+    AthenaRowFormatSerde,
 )
-
 from pyathena.sqlalchemy.types import AthenaDate, AthenaTimestamp
 from pyathena.sqlalchemy.util import _HashableDict
 

--- a/tests/pyathena/sqlalchemy/test_base.py
+++ b/tests/pyathena/sqlalchemy/test_base.py
@@ -1270,50 +1270,55 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
         assert actual.c.col_partition_2.dialect_options["awsathena"]["partition"]
 
     def test_create_iceberg_table_with_partition(self, engine):
-            engine, conn = engine
-            table_name = "test_create_iceberg_table_with_partition"
-            table_comment = "table comment"
-            column_comment = "column comment"
-            table = Table(
-                table_name,
-                MetaData(schema=ENV.schema),
-                Column("col_1", types.String, comment=column_comment),
-                Column("col_partition_1", types.String, awsathena_partition=True, comment=column_comment),
-                Column("col_partition_2", types.Integer, awsathena_partition=True),
-                Column("col_2", types.Integer),
-                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
-                comment=table_comment,
-                awsathena_tblproperties={"table_type": "ICEBERG"}
-            )
-            ddl = CreateTable(table).compile(bind=conn)
-            table.create(bind=conn)
-            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+        engine, conn = engine
+        table_name = "test_create_iceberg_table_with_partition"
+        table_comment = "table comment"
+        column_comment = "column comment"
+        table = Table(
+            table_name,
+            MetaData(schema=ENV.schema),
+            Column("col_1", types.String, comment=column_comment),
+            Column(
+                "col_partition_1",
+                types.String,
+                awsathena_partition=True,
+                comment=column_comment
+            ),
+            Column("col_partition_2", types.Integer, awsathena_partition=True),
+            Column("col_2", types.Integer),
+            awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+            comment=table_comment,
+            awsathena_tblproperties={"table_type": "ICEBERG"}
+        )
+        ddl = CreateTable(table).compile(bind=conn)
+        table.create(bind=conn)
+        actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
 
-            assert str(ddl) == textwrap.dedent(
-                f"""
-                CREATE TABLE {ENV.schema}.{table_name} (
-                \tcol_1 STRING COMMENT '{column_comment}',
-                \tcol_partition_1 STRING COMMENT 'column comment',
-                \tcol_partition_2 INT,
-                \tcol_2 INT
-                )
-                COMMENT '{table_comment}'
-                PARTITIONED BY (
-                \tcol_partition_1,
-                \tcol_partition_2
-                )
-                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
-                TBLPROPERTIES (
-                \t'table_type' = 'ICEBERG'
-                )
-                """
+        assert str(ddl) == textwrap.dedent(
+            f"""
+            CREATE TABLE {ENV.schema}.{table_name} (
+            \tcol_1 STRING COMMENT '{column_comment}',
+            \tcol_partition_1 STRING COMMENT 'column comment',
+            \tcol_partition_2 INT,
+            \tcol_2 INT
             )
-            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
-            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
-            assert actual.c.col_partition_1.dialect_options["awsathena"]["partition"]
-            assert actual.c.col_partition_2.dialect_options["awsathena"]["partition"]
-            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
-            assert tblproperties["table_type"] == "ICEBERG"
+            COMMENT '{table_comment}'
+            PARTITIONED BY (
+            \tcol_partition_1,
+            \tcol_partition_2
+            )
+            LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+            TBLPROPERTIES (
+            \t'table_type' = 'ICEBERG'
+            )
+            """
+        )
+        assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+        assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+        assert actual.c.col_partition_1.dialect_options["awsathena"]["partition"]
+        assert actual.c.col_partition_2.dialect_options["awsathena"]["partition"]
+        tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+        assert tblproperties["table_type"] == "ICEBERG"
 
     def test_create_table_with_date_partition(self, engine):
         engine, conn = engine
@@ -1366,278 +1371,313 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
         assert tblproperties["projection.dt.format"] == "yyyy-MM-dd"
 
     def test_create_iceberg_table_with_date_partition(self, engine):
-            engine, conn = engine
-            table_name = "test_create_iceberg_table_with_date_partition"
-            table = Table(
-                table_name,
-                MetaData(schema=ENV.schema),
-                Column("col_1", types.String),
-                Column("col_2", types.Integer),
-                Column("dt", types.Date, awsathena_partition=True),
-                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
-                awsathena_tblproperties={"table_type": "ICEBERG"},
-            )
-            ddl = CreateTable(table).compile(bind=conn)
-            table.create(bind=conn)
-            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+        engine, conn = engine
+        table_name = "test_create_iceberg_table_with_date_partition"
+        table = Table(
+            table_name,
+            MetaData(schema=ENV.schema),
+            Column("col_1", types.String),
+            Column("col_2", types.Integer),
+            Column("dt", types.Date, awsathena_partition=True),
+            awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+            awsathena_tblproperties={"table_type": "ICEBERG"},
+        )
+        ddl = CreateTable(table).compile(bind=conn)
+        table.create(bind=conn)
+        actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
 
-            assert str(ddl) == textwrap.dedent(
-                f"""
-                CREATE TABLE {ENV.schema}.{table_name} (
-                \tcol_1 STRING,
-                \tcol_2 INT
-                \tdt DATE
-                )
-                PARTITIONED BY (
-                \tdt
-                )
-                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
-                TBLPROPERTIES (
-                \t'table_type' = 'ICEBERG'
-                )
-                """
+        assert str(ddl) == textwrap.dedent(
+            f"""
+            CREATE TABLE {ENV.schema}.{table_name} (
+            \tcol_1 STRING,
+            \tcol_2 INT
+            \tdt DATE
             )
-            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
-            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
-            assert actual.c.dt.dialect_options["awsathena"]["partition"]
-            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
-            assert tblproperties["table_type"] == "ICEBERG"
+            PARTITIONED BY (
+            \tdt
+            )
+            LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+            TBLPROPERTIES (
+            \t'table_type' = 'ICEBERG'
+            )
+            """
+        )
+        assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+        assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+        assert actual.c.dt.dialect_options["awsathena"]["partition"]
+        tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+        assert tblproperties["table_type"] == "ICEBERG"
 
     def test_create_iceberg_table_with_year_partition_transform(self, engine):
-            engine, conn = engine
-            table_name = "test_create_iceberg_table_with_year_partition_transform"
-            table = Table(
-                table_name,
-                MetaData(schema=ENV.schema),
-                Column("col_1", types.String),
-                Column("col_2", types.Integer),
-                Column("dt", types.Date, awsathena_partition=True, awsathena_partition_transform='year'),
-                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
-                awsathena_tblproperties={"table_type": "ICEBERG"},
-            )
-            ddl = CreateTable(table).compile(bind=conn)
-            table.create(bind=conn)
-            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+        engine, conn = engine
+        table_name = "test_create_iceberg_table_with_year_partition_transform"
+        table = Table(
+            table_name,
+            MetaData(schema=ENV.schema),
+            Column("col_1", types.String),
+            Column("col_2", types.Integer),
+            Column(
+                "dt",
+                types.Date,
+                awsathena_partition=True,
+                awsathena_partition_transform='year'
+            ),
+            awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+            awsathena_tblproperties={"table_type": "ICEBERG"},
+        )
+        ddl = CreateTable(table).compile(bind=conn)
+        table.create(bind=conn)
+        actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
 
-            assert str(ddl) == textwrap.dedent(
-                f"""
-                CREATE TABLE {ENV.schema}.{table_name} (
-                \tcol_1 STRING,
-                \tcol_2 INT
-                \tdt DATE
-                )
-                PARTITIONED BY (
-                \tyear(dt)
-                )
-                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
-                TBLPROPERTIES (
-                \t'table_type' = 'ICEBERG'
-                )
-                """
+        assert str(ddl) == textwrap.dedent(
+            f"""
+            CREATE TABLE {ENV.schema}.{table_name} (
+            \tcol_1 STRING,
+            \tcol_2 INT
+            \tdt DATE
             )
-            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
-            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
-            assert actual.c.dt.dialect_options["awsathena"]["partition"]
-            assert actual.c.dt.dialect_options["awsathena"]["partition_transform"] == 'year'
-            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
-            assert tblproperties["table_type"] == "ICEBERG"
+            PARTITIONED BY (
+            \tyear(dt)
+            )
+            LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+            TBLPROPERTIES (
+            \t'table_type' = 'ICEBERG'
+            )
+            """
+        )
+        assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+        assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+        assert actual.c.dt.dialect_options["awsathena"]["partition"]
+        assert actual.c.dt.dialect_options["awsathena"]["partition_transform"] == 'year'
+        tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+        assert tblproperties["table_type"] == "ICEBERG"
 
     def test_create_iceberg_table_with_month_partition_transform(self, engine):
-            engine, conn = engine
-            table_name = "test_create_iceberg_table_with_month_partition_transform"
-            table = Table(
-                table_name,
-                MetaData(schema=ENV.schema),
-                Column("col_1", types.String),
-                Column("col_2", types.Integer),
-                Column("dt", types.Date, awsathena_partition=True, awsathena_partition_transform='month'),
-                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
-                awsathena_tblproperties={"table_type": "ICEBERG"},
-            )
-            ddl = CreateTable(table).compile(bind=conn)
-            table.create(bind=conn)
-            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+        engine, conn = engine
+        table_name = "test_create_iceberg_table_with_month_partition_transform"
+        table = Table(
+            table_name,
+            MetaData(schema=ENV.schema),
+            Column("col_1", types.String),
+            Column("col_2", types.Integer),
+            Column(
+                "dt",
+                types.Date,
+                awsathena_partition=True,
+                awsathena_partition_transform='month'
+            ),
+            awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+            awsathena_tblproperties={"table_type": "ICEBERG"},
+        )
+        ddl = CreateTable(table).compile(bind=conn)
+        table.create(bind=conn)
+        actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
 
-            assert str(ddl) == textwrap.dedent(
-                f"""
-                CREATE TABLE {ENV.schema}.{table_name} (
-                \tcol_1 STRING,
-                \tcol_2 INT
-                \tdt DATE
-                )
-                PARTITIONED BY (
-                \tmonth(dt)
-                )
-                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
-                TBLPROPERTIES (
-                \t'table_type' = 'ICEBERG'
-                )
-                """
+        assert str(ddl) == textwrap.dedent(
+            f"""
+            CREATE TABLE {ENV.schema}.{table_name} (
+            \tcol_1 STRING,
+            \tcol_2 INT
+            \tdt DATE
             )
-            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
-            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
-            assert actual.c.dt.dialect_options["awsathena"]["partition"]
-            assert actual.c.dt.dialect_options["awsathena"]["partition_transform"] == 'month'
-            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
-            assert tblproperties["table_type"] == "ICEBERG"
+            PARTITIONED BY (
+            \tmonth(dt)
+            )
+            LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+            TBLPROPERTIES (
+            \t'table_type' = 'ICEBERG'
+            )
+            """
+        )
+        assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+        assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+        assert actual.c.dt.dialect_options["awsathena"]["partition"]
+        assert actual.c.dt.dialect_options["awsathena"]["partition_transform"] == 'month'
+        tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+        assert tblproperties["table_type"] == "ICEBERG"
 
     def test_create_iceberg_table_with_day_partition_transform(self, engine):
-            engine, conn = engine
-            table_name = "test_create_iceberg_table_with_day_partition_transform"
-            table = Table(
-                table_name,
-                MetaData(schema=ENV.schema),
-                Column("col_1", types.String),
-                Column("col_2", types.Integer),
-                Column("dt", types.Date, awsathena_partition=True, awsathena_partition_transform='day'),
-                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
-                awsathena_tblproperties={"table_type": "ICEBERG"},
-            )
-            ddl = CreateTable(table).compile(bind=conn)
-            table.create(bind=conn)
-            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+        engine, conn = engine
+        table_name = "test_create_iceberg_table_with_day_partition_transform"
+        table = Table(
+            table_name,
+            MetaData(schema=ENV.schema),
+            Column("col_1", types.String),
+            Column("col_2", types.Integer),
+            Column("dt", types.Date, awsathena_partition=True, awsathena_partition_transform='day'),
+            awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+            awsathena_tblproperties={"table_type": "ICEBERG"},
+        )
+        ddl = CreateTable(table).compile(bind=conn)
+        table.create(bind=conn)
+        actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
 
-            assert str(ddl) == textwrap.dedent(
-                f"""
-                CREATE TABLE {ENV.schema}.{table_name} (
-                \tcol_1 STRING,
-                \tcol_2 INT
-                \tdt DATE
-                )
-                PARTITIONED BY (
-                \tday(dt)
-                )
-                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
-                TBLPROPERTIES (
-                \t'table_type' = 'ICEBERG'
-                )
-                """
+        assert str(ddl) == textwrap.dedent(
+            f"""
+            CREATE TABLE {ENV.schema}.{table_name} (
+            \tcol_1 STRING,
+            \tcol_2 INT
+            \tdt DATE
             )
-            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
-            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
-            assert actual.c.dt.dialect_options["awsathena"]["partition"]
-            assert actual.c.dt.dialect_options["awsathena"]["partition_transform"] == 'day'
-            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
-            assert tblproperties["table_type"] == "ICEBERG"
+            PARTITIONED BY (
+            \tday(dt)
+            )
+            LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+            TBLPROPERTIES (
+            \t'table_type' = 'ICEBERG'
+            )
+            """
+        )
+        assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+        assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+        assert actual.c.dt.dialect_options["awsathena"]["partition"]
+        assert actual.c.dt.dialect_options["awsathena"]["partition_transform"] == 'day'
+        tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+        assert tblproperties["table_type"] == "ICEBERG"
 
     def test_create_iceberg_table_with_hour_partition_transform(self, engine):
-            engine, conn = engine
-            table_name = "test_create_iceberg_table_with_hour_partition_transform"
-            table = Table(
-                table_name,
-                MetaData(schema=ENV.schema),
-                Column("col_1", types.String),
-                Column("col_2", types.Integer),
-                Column("ts", types.TIMESTAMP, awsathena_partition=True, awsathena_partition_transform='hour'),
-                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
-                awsathena_tblproperties={"table_type": "ICEBERG"},
-            )
-            ddl = CreateTable(table).compile(bind=conn)
-            table.create(bind=conn)
-            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+        engine, conn = engine
+        table_name = "test_create_iceberg_table_with_hour_partition_transform"
+        table = Table(
+            table_name,
+            MetaData(schema=ENV.schema),
+            Column("col_1", types.String),
+            Column("col_2", types.Integer),
+            Column(
+                "ts",
+                types.TIMESTAMP,
+                awsathena_partition=True,
+                awsathena_partition_transform='hour'
+            ),
+            awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+            awsathena_tblproperties={"table_type": "ICEBERG"},
+        )
+        ddl = CreateTable(table).compile(bind=conn)
+        table.create(bind=conn)
+        actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
 
-            assert str(ddl) == textwrap.dedent(
-                f"""
-                CREATE TABLE {ENV.schema}.{table_name} (
-                \tcol_1 STRING,
-                \tcol_2 INT
-                \tts TIMESTAMP
-                )
-                PARTITIONED BY (
-                \thour(ts)
-                )
-                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
-                TBLPROPERTIES (
-                \t'table_type' = 'ICEBERG'
-                )
-                """
+        assert str(ddl) == textwrap.dedent(
+            f"""
+            CREATE TABLE {ENV.schema}.{table_name} (
+            \tcol_1 STRING,
+            \tcol_2 INT
+            \tts TIMESTAMP
             )
-            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
-            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
-            assert actual.c.ts.dialect_options["awsathena"]["partition"]
-            assert actual.c.ts.dialect_options["awsathena"]["partition_transform"] == 'hour'
-            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
-            assert tblproperties["table_type"] == "ICEBERG"
+            PARTITIONED BY (
+            \thour(ts)
+            )
+            LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+            TBLPROPERTIES (
+            \t'table_type' = 'ICEBERG'
+            )
+            """
+        )
+        assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+        assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+        assert actual.c.ts.dialect_options["awsathena"]["partition"]
+        assert actual.c.ts.dialect_options["awsathena"]["partition_transform"] == 'hour'
+        tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+        assert tblproperties["table_type"] == "ICEBERG"
 
     def test_create_iceberg_table_with_bucket_partition_transform(self, engine):
-            engine, conn = engine
-            table_name = "test_create_iceberg_table_with_bucket_partition_transform"
-            table = Table(
-                table_name,
-                MetaData(schema=ENV.schema),
-                Column("col_1", types.String),
-                Column("col_2", types.Integer),
-                Column("col_partition_bucket_1", types.Integer, awsathena_partition=True, awsathena_partition_transform='bucket', awsathena_partition_transform_bucket_count=5),
-                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
-                awsathena_tblproperties={"table_type": "ICEBERG"},
-            )
-            ddl = CreateTable(table).compile(bind=conn)
-            table.create(bind=conn)
-            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+        engine, conn = engine
+        table_name = "test_create_iceberg_table_with_bucket_partition_transform"
+        table = Table(
+            table_name,
+            MetaData(schema=ENV.schema),
+            Column("col_1", types.String),
+            Column("col_2", types.Integer),
+            Column(
+                "col_partition_bucket_1",
+                types.Integer,
+                awsathena_partition=True,
+                awsathena_partition_transform='bucket',
+                awsathena_partition_transform_bucket_count=5
+            ),
+            awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+            awsathena_tblproperties={"table_type": "ICEBERG"},
+        )
+        ddl = CreateTable(table).compile(bind=conn)
+        table.create(bind=conn)
+        actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
 
-            assert str(ddl) == textwrap.dedent(
-                f"""
-                CREATE TABLE {ENV.schema}.{table_name} (
-                \tcol_1 STRING,
-                \tcol_2 INT
-                \tcol_partition_bucket_1 INT
-                )
-                PARTITIONED BY (
-                \tbucket(5, col_partition_bucket_1)
-                )
-                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
-                TBLPROPERTIES (
-                \t'table_type' = 'ICEBERG'
-                )
-                """
+        assert str(ddl) == textwrap.dedent(
+            f"""
+            CREATE TABLE {ENV.schema}.{table_name} (
+            \tcol_1 STRING,
+            \tcol_2 INT
+            \tcol_partition_bucket_1 INT
             )
-            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
-            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
-            assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition"]
-            assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition_transform"] == 'bucket'
-            assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition_transform_bucket_count"] == 5
-            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
-            assert tblproperties["table_type"] == "ICEBERG"
+            PARTITIONED BY (
+            \tbucket(5, col_partition_bucket_1)
+            )
+            LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+            TBLPROPERTIES (
+            \t'table_type' = 'ICEBERG'
+            )
+            """
+        )
+        assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+        assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+        assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition"]
+        partition_transform = \
+            actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition_transform"]
+        assert partition_transform == 'bucket'
+        partition_transform_bucket_count = \
+            actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition_transform_bucket_count"]
+        assert partition_transform_bucket_count == 5
+        tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+        assert tblproperties["table_type"] == "ICEBERG"
 
     def test_create_iceberg_table_with_truncate_partition_transform(self, engine):
-            engine, conn = engine
-            table_name = "test_create_iceberg_table_with_truncate_partition_transform"
-            table = Table(
-                table_name,
-                MetaData(schema=ENV.schema),
-                Column("col_1", types.String),
-                Column("col_2", types.Integer),
-                Column("col_partition_truncate_1", types.String, awsathena_partition=True, awsathena_partition_transform='truncate', awsathena_partition_transform_truncate_length=5),
-                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
-                awsathena_tblproperties={"table_type": "ICEBERG"},
-            )
-            ddl = CreateTable(table).compile(bind=conn)
-            table.create(bind=conn)
-            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+        engine, conn = engine
+        table_name = "test_create_iceberg_table_with_truncate_partition_transform"
+        table = Table(
+            table_name,
+            MetaData(schema=ENV.schema),
+            Column("col_1", types.String),
+            Column("col_2", types.Integer),
+            Column(
+                "col_partition_truncate_1",
+                types.String,
+                awsathena_partition=True,
+                awsathena_partition_transform='truncate',
+                awsathena_partition_transform_truncate_length=5
+            ),
+            awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+            awsathena_tblproperties={"table_type": "ICEBERG"},
+        )
+        ddl = CreateTable(table).compile(bind=conn)
+        table.create(bind=conn)
+        actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
 
-            assert str(ddl) == textwrap.dedent(
-                f"""
-                CREATE TABLE {ENV.schema}.{table_name} (
-                \tcol_1 STRING,
-                \tcol_2 INT
-                \tcol_partition_truncate_1
-                )
-                PARTITIONED BY (
-                \ttruncate(5, col_partition_truncate_1)
-                )
-                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
-                TBLPROPERTIES (
-                \t'table_type' = 'ICEBERG'
-                )
-                """
+        assert str(ddl) == textwrap.dedent(
+            f"""
+            CREATE TABLE {ENV.schema}.{table_name} (
+            \tcol_1 STRING,
+            \tcol_2 INT
+            \tcol_partition_truncate_1
             )
-            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
-            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
-            assert actual.c.col_partition_truncate_1.dialect_options["awsathena"]["partition"]
-            assert actual.c.col_partition_truncate_1.dialect_options["awsathena"]["partition_transform"] == 'truncate'
-            assert actual.c.col_partition_truncate_1.dialect_options["awsathena"]["partition_transform_truncate_length"] == 5
-            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
-            assert tblproperties["table_type"] == "ICEBERG"
+            PARTITIONED BY (
+            \ttruncate(5, col_partition_truncate_1)
+            )
+            LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+            TBLPROPERTIES (
+            \t'table_type' = 'ICEBERG'
+            )
+            """
+        )
+        assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+        assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+        assert actual.c.col_partition_truncate_1.dialect_options["awsathena"]["partition"]
+        partition_transform = \
+            actual.c.col_partition_truncate_1.dialect_options["awsathena"]["partition_transform"]
+        assert partition_transform == 'truncate'
+        partition_transform_truncate_length = \
+            actual.c.col_partition_truncate_1.dialect_options["awsathena"]["partition_transform_truncate_length"]
+        assert partition_transform_truncate_length == 5
+        tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+        assert tblproperties["table_type"] == "ICEBERG"
 
     def test_insert_from_select_cte_follows_insert_one(self, engine):
         engine, conn = engine

--- a/tests/pyathena/sqlalchemy/test_base.py
+++ b/tests/pyathena/sqlalchemy/test_base.py
@@ -1269,6 +1269,52 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
         assert actual.c.col_partition_1.dialect_options["awsathena"]["partition"]
         assert actual.c.col_partition_2.dialect_options["awsathena"]["partition"]
 
+    def test_create_iceberg_table_with_partition(self, engine):
+            engine, conn = engine
+            table_name = "test_create_iceberg_table_with_partition"
+            table_comment = "table comment"
+            column_comment = "column comment"
+            table = Table(
+                table_name,
+                MetaData(schema=ENV.schema),
+                Column("col_1", types.String, comment=column_comment),
+                Column("col_partition_1", types.String, awsathena_partition=True, comment=column_comment),
+                Column("col_partition_2", types.Integer, awsathena_partition=True),
+                Column("col_2", types.Integer),
+                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+                comment=table_comment,
+                awsathena_tblproperties={"table_type": "ICEBERG"}
+            )
+            ddl = CreateTable(table).compile(bind=conn)
+            table.create(bind=conn)
+            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+
+            assert str(ddl) == textwrap.dedent(
+                f"""
+                CREATE TABLE {ENV.schema}.{table_name} (
+                \tcol_1 STRING COMMENT '{column_comment}',
+                \tcol_partition_1 STRING COMMENT 'column comment',
+                \tcol_partition_2 INT,
+                \tcol_2 INT
+                )
+                COMMENT '{table_comment}'
+                PARTITIONED BY (
+                \tcol_partition_1,
+                \tcol_partition_2
+                )
+                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+                TBLPROPERTIES (
+                \t'table_type' = 'ICEBERG'
+                )
+                """
+            )
+            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+            assert actual.c.col_partition_1.dialect_options["awsathena"]["partition"]
+            assert actual.c.col_partition_2.dialect_options["awsathena"]["partition"]
+            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+            assert tblproperties["table_type"] == "ICEBERG"
+
     def test_create_table_with_date_partition(self, engine):
         engine, conn = engine
         table_name = "test_create_table_with_date_partition"
@@ -1318,6 +1364,280 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
         assert tblproperties["projection.dt.type"] == "date"
         assert tblproperties["projection.dt.range"] == "NOW-1YEARS,NOW"
         assert tblproperties["projection.dt.format"] == "yyyy-MM-dd"
+
+    def test_create_iceberg_table_with_date_partition(self, engine):
+            engine, conn = engine
+            table_name = "test_create_iceberg_table_with_date_partition"
+            table = Table(
+                table_name,
+                MetaData(schema=ENV.schema),
+                Column("col_1", types.String),
+                Column("col_2", types.Integer),
+                Column("dt", types.Date, awsathena_partition=True),
+                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+                awsathena_tblproperties={"table_type": "ICEBERG"},
+            )
+            ddl = CreateTable(table).compile(bind=conn)
+            table.create(bind=conn)
+            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+
+            assert str(ddl) == textwrap.dedent(
+                f"""
+                CREATE TABLE {ENV.schema}.{table_name} (
+                \tcol_1 STRING,
+                \tcol_2 INT
+                \tdt DATE
+                )
+                PARTITIONED BY (
+                \tdt
+                )
+                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+                TBLPROPERTIES (
+                \t'table_type' = 'ICEBERG'
+                )
+                """
+            )
+            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+            assert actual.c.dt.dialect_options["awsathena"]["partition"]
+            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+            assert tblproperties["table_type"] == "ICEBERG"
+
+    def test_create_iceberg_table_with_year_partition_transform(self, engine):
+            engine, conn = engine
+            table_name = "test_create_iceberg_table_with_year_partition_transform"
+            table = Table(
+                table_name,
+                MetaData(schema=ENV.schema),
+                Column("col_1", types.String),
+                Column("col_2", types.Integer),
+                Column("dt", types.Date, awsathena_partition=True, awsathena_partition_transform='year'),
+                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+                awsathena_tblproperties={"table_type": "ICEBERG"},
+            )
+            ddl = CreateTable(table).compile(bind=conn)
+            table.create(bind=conn)
+            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+
+            assert str(ddl) == textwrap.dedent(
+                f"""
+                CREATE TABLE {ENV.schema}.{table_name} (
+                \tcol_1 STRING,
+                \tcol_2 INT
+                \tdt DATE
+                )
+                PARTITIONED BY (
+                \tyear(dt)
+                )
+                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+                TBLPROPERTIES (
+                \t'table_type' = 'ICEBERG'
+                )
+                """
+            )
+            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+            assert actual.c.dt.dialect_options["awsathena"]["partition"]
+            assert actual.c.dt.dialect_options["awsathena"]["partition_transform"] == 'year'
+            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+            assert tblproperties["table_type"] == "ICEBERG"
+
+    def test_create_iceberg_table_with_month_partition_transform(self, engine):
+            engine, conn = engine
+            table_name = "test_create_iceberg_table_with_month_partition_transform"
+            table = Table(
+                table_name,
+                MetaData(schema=ENV.schema),
+                Column("col_1", types.String),
+                Column("col_2", types.Integer),
+                Column("dt", types.Date, awsathena_partition=True, awsathena_partition_transform='month'),
+                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+                awsathena_tblproperties={"table_type": "ICEBERG"},
+            )
+            ddl = CreateTable(table).compile(bind=conn)
+            table.create(bind=conn)
+            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+
+            assert str(ddl) == textwrap.dedent(
+                f"""
+                CREATE TABLE {ENV.schema}.{table_name} (
+                \tcol_1 STRING,
+                \tcol_2 INT
+                \tdt DATE
+                )
+                PARTITIONED BY (
+                \tmonth(dt)
+                )
+                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+                TBLPROPERTIES (
+                \t'table_type' = 'ICEBERG'
+                )
+                """
+            )
+            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+            assert actual.c.dt.dialect_options["awsathena"]["partition"]
+            assert actual.c.dt.dialect_options["awsathena"]["partition_transform"] == 'month'
+            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+            assert tblproperties["table_type"] == "ICEBERG"
+
+    def test_create_iceberg_table_with_day_partition_transform(self, engine):
+            engine, conn = engine
+            table_name = "test_create_iceberg_table_with_day_partition_transform"
+            table = Table(
+                table_name,
+                MetaData(schema=ENV.schema),
+                Column("col_1", types.String),
+                Column("col_2", types.Integer),
+                Column("dt", types.Date, awsathena_partition=True, awsathena_partition_transform='day'),
+                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+                awsathena_tblproperties={"table_type": "ICEBERG"},
+            )
+            ddl = CreateTable(table).compile(bind=conn)
+            table.create(bind=conn)
+            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+
+            assert str(ddl) == textwrap.dedent(
+                f"""
+                CREATE TABLE {ENV.schema}.{table_name} (
+                \tcol_1 STRING,
+                \tcol_2 INT
+                \tdt DATE
+                )
+                PARTITIONED BY (
+                \tday(dt)
+                )
+                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+                TBLPROPERTIES (
+                \t'table_type' = 'ICEBERG'
+                )
+                """
+            )
+            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+            assert actual.c.dt.dialect_options["awsathena"]["partition"]
+            assert actual.c.dt.dialect_options["awsathena"]["partition_transform"] == 'day'
+            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+            assert tblproperties["table_type"] == "ICEBERG"
+
+    def test_create_iceberg_table_with_hour_partition_transform(self, engine):
+            engine, conn = engine
+            table_name = "test_create_iceberg_table_with_hour_partition_transform"
+            table = Table(
+                table_name,
+                MetaData(schema=ENV.schema),
+                Column("col_1", types.String),
+                Column("col_2", types.Integer),
+                Column("ts", types.TIMESTAMP, awsathena_partition=True, awsathena_partition_transform='hour'),
+                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+                awsathena_tblproperties={"table_type": "ICEBERG"},
+            )
+            ddl = CreateTable(table).compile(bind=conn)
+            table.create(bind=conn)
+            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+
+            assert str(ddl) == textwrap.dedent(
+                f"""
+                CREATE TABLE {ENV.schema}.{table_name} (
+                \tcol_1 STRING,
+                \tcol_2 INT
+                \tts TIMESTAMP
+                )
+                PARTITIONED BY (
+                \thour(ts)
+                )
+                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+                TBLPROPERTIES (
+                \t'table_type' = 'ICEBERG'
+                )
+                """
+            )
+            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+            assert actual.c.ts.dialect_options["awsathena"]["partition"]
+            assert actual.c.ts.dialect_options["awsathena"]["partition_transform"] == 'hour'
+            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+            assert tblproperties["table_type"] == "ICEBERG"
+
+    def test_create_iceberg_table_with_bucket_partition_transform(self, engine):
+            engine, conn = engine
+            table_name = "test_create_iceberg_table_with_bucket_partition_transform"
+            table = Table(
+                table_name,
+                MetaData(schema=ENV.schema),
+                Column("col_1", types.String),
+                Column("col_2", types.Integer),
+                Column("col_partition_bucket_1", types.Integer, awsathena_partition=True, awsathena_partition_transform='bucket', awsathena_partition_transform_bucket_count=5),
+                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+                awsathena_tblproperties={"table_type": "ICEBERG"},
+            )
+            ddl = CreateTable(table).compile(bind=conn)
+            table.create(bind=conn)
+            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+
+            assert str(ddl) == textwrap.dedent(
+                f"""
+                CREATE TABLE {ENV.schema}.{table_name} (
+                \tcol_1 STRING,
+                \tcol_2 INT
+                \tcol_partition_bucket_1 INT
+                )
+                PARTITIONED BY (
+                \tbucket(5, col_partition_bucket_1)
+                )
+                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+                TBLPROPERTIES (
+                \t'table_type' = 'ICEBERG'
+                )
+                """
+            )
+            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+            assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition"]
+            assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition_transform"] == 'bucket'
+            assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition_transform_bucket_count"] == 5
+            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+            assert tblproperties["table_type"] == "ICEBERG"
+
+    def test_create_iceberg_table_with_truncate_partition_transform(self, engine):
+            engine, conn = engine
+            table_name = "test_create_iceberg_table_with_truncate_partition_transform"
+            table = Table(
+                table_name,
+                MetaData(schema=ENV.schema),
+                Column("col_1", types.String),
+                Column("col_2", types.Integer),
+                Column("col_partition_truncate_1", types.String, awsathena_partition=True, awsathena_partition_transform='truncate', awsathena_partition_transform_truncate_length=5),
+                awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
+                awsathena_tblproperties={"table_type": "ICEBERG"},
+            )
+            ddl = CreateTable(table).compile(bind=conn)
+            table.create(bind=conn)
+            actual = Table(table_name, MetaData(schema=ENV.schema), autoload_with=conn)
+
+            assert str(ddl) == textwrap.dedent(
+                f"""
+                CREATE TABLE {ENV.schema}.{table_name} (
+                \tcol_1 STRING,
+                \tcol_2 INT
+                \tcol_partition_bucket_1 STRING
+                )
+                PARTITIONED BY (
+                \ttruncate(5, col_partition_truncate_1)
+                )
+                LOCATION '{ENV.s3_staging_dir}{ENV.schema}/{table_name}/'
+                TBLPROPERTIES (
+                \t'table_type' = 'ICEBERG'
+                )
+                """
+            )
+            assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
+            assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
+            assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition"]
+            assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition_transform"] == 'truncate'
+            assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition_transform_truncate_length"] == 5
+            tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
+            assert tblproperties["table_type"] == "ICEBERG"
 
     def test_insert_from_select_cte_follows_insert_one(self, engine):
         engine, conn = engine

--- a/tests/pyathena/sqlalchemy/test_base.py
+++ b/tests/pyathena/sqlalchemy/test_base.py
@@ -1624,7 +1624,8 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition_transform"]
         assert partition_transform == 'bucket'
         partition_transform_bucket_count = \
-            actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition_transform_bucket_count"]
+            actual.c.col_partition_bucket_1.\
+            dialect_options["awsathena"]["partition_transform_bucket_count"]
         assert partition_transform_bucket_count == 5
         tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
         assert tblproperties["table_type"] == "ICEBERG"
@@ -1674,7 +1675,8 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             actual.c.col_partition_truncate_1.dialect_options["awsathena"]["partition_transform"]
         assert partition_transform == 'truncate'
         partition_transform_truncate_length = \
-            actual.c.col_partition_truncate_1.dialect_options["awsathena"]["partition_transform_truncate_length"]
+            actual.c.col_partition_truncate_1.\
+            dialect_options["awsathena"]["partition_transform_truncate_length"]
         assert partition_transform_truncate_length == 5
         tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
         assert tblproperties["table_type"] == "ICEBERG"

--- a/tests/pyathena/sqlalchemy/test_base.py
+++ b/tests/pyathena/sqlalchemy/test_base.py
@@ -1622,7 +1622,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             CREATE TABLE {ENV.schema}.{table_name} (
             \tcol_1 STRING,
             \tcol_2 INT,
-            \tcol_partition_truncate_1
+            \tcol_partition_truncate_1 STRING
             )
             PARTITIONED BY (
             \ttruncate(5, col_partition_truncate_1)

--- a/tests/pyathena/sqlalchemy/test_base.py
+++ b/tests/pyathena/sqlalchemy/test_base.py
@@ -1279,16 +1279,13 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             MetaData(schema=ENV.schema),
             Column("col_1", types.String, comment=column_comment),
             Column(
-                "col_partition_1",
-                types.String,
-                awsathena_partition=True,
-                comment=column_comment
+                "col_partition_1", types.String, awsathena_partition=True, comment=column_comment
             ),
             Column("col_partition_2", types.Integer, awsathena_partition=True),
             Column("col_2", types.Integer),
             awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
             comment=table_comment,
-            awsathena_tblproperties={"table_type": "ICEBERG"}
+            awsathena_tblproperties={"table_type": "ICEBERG"},
         )
         ddl = CreateTable(table).compile(bind=conn)
         table.create(bind=conn)
@@ -1417,10 +1414,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             Column("col_1", types.String),
             Column("col_2", types.Integer),
             Column(
-                "dt",
-                types.Date,
-                awsathena_partition=True,
-                awsathena_partition_transform='year'
+                "dt", types.Date, awsathena_partition=True, awsathena_partition_transform="year"
             ),
             awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
             awsathena_tblproperties={"table_type": "ICEBERG"},
@@ -1448,7 +1442,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
         assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
         assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
         assert actual.c.dt.dialect_options["awsathena"]["partition"]
-        assert actual.c.dt.dialect_options["awsathena"]["partition_transform"] == 'year'
+        assert actual.c.dt.dialect_options["awsathena"]["partition_transform"] == "year"
         tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
         assert tblproperties["table_type"] == "ICEBERG"
 
@@ -1461,10 +1455,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             Column("col_1", types.String),
             Column("col_2", types.Integer),
             Column(
-                "dt",
-                types.Date,
-                awsathena_partition=True,
-                awsathena_partition_transform='month'
+                "dt", types.Date, awsathena_partition=True, awsathena_partition_transform="month"
             ),
             awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
             awsathena_tblproperties={"table_type": "ICEBERG"},
@@ -1492,7 +1483,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
         assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
         assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
         assert actual.c.dt.dialect_options["awsathena"]["partition"]
-        assert actual.c.dt.dialect_options["awsathena"]["partition_transform"] == 'month'
+        assert actual.c.dt.dialect_options["awsathena"]["partition_transform"] == "month"
         tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
         assert tblproperties["table_type"] == "ICEBERG"
 
@@ -1504,7 +1495,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             MetaData(schema=ENV.schema),
             Column("col_1", types.String),
             Column("col_2", types.Integer),
-            Column("dt", types.Date, awsathena_partition=True, awsathena_partition_transform='day'),
+            Column("dt", types.Date, awsathena_partition=True, awsathena_partition_transform="day"),
             awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
             awsathena_tblproperties={"table_type": "ICEBERG"},
         )
@@ -1531,7 +1522,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
         assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
         assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
         assert actual.c.dt.dialect_options["awsathena"]["partition"]
-        assert actual.c.dt.dialect_options["awsathena"]["partition_transform"] == 'day'
+        assert actual.c.dt.dialect_options["awsathena"]["partition_transform"] == "day"
         tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
         assert tblproperties["table_type"] == "ICEBERG"
 
@@ -1547,7 +1538,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
                 "ts",
                 types.TIMESTAMP,
                 awsathena_partition=True,
-                awsathena_partition_transform='hour'
+                awsathena_partition_transform="hour",
             ),
             awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
             awsathena_tblproperties={"table_type": "ICEBERG"},
@@ -1575,7 +1566,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
         assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
         assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
         assert actual.c.ts.dialect_options["awsathena"]["partition"]
-        assert actual.c.ts.dialect_options["awsathena"]["partition_transform"] == 'hour'
+        assert actual.c.ts.dialect_options["awsathena"]["partition_transform"] == "hour"
         tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
         assert tblproperties["table_type"] == "ICEBERG"
 
@@ -1591,8 +1582,8 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
                 "col_partition_bucket_1",
                 types.Integer,
                 awsathena_partition=True,
-                awsathena_partition_transform='bucket',
-                awsathena_partition_transform_bucket_count=5
+                awsathena_partition_transform="bucket",
+                awsathena_partition_transform_bucket_count=5,
             ),
             awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
             awsathena_tblproperties={"table_type": "ICEBERG"},
@@ -1620,12 +1611,13 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
         assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
         assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
         assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition"]
-        partition_transform = \
-            actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition_transform"]
-        assert partition_transform == 'bucket'
-        partition_transform_bucket_count = \
-            actual.c.col_partition_bucket_1.\
-            dialect_options["awsathena"]["partition_transform_bucket_count"]
+        partition_transform = actual.c.col_partition_bucket_1.dialect_options["awsathena"][
+            "partition_transform"
+        ]
+        assert partition_transform == "bucket"
+        partition_transform_bucket_count = actual.c.col_partition_bucket_1.dialect_options[
+            "awsathena"
+        ]["partition_transform_bucket_count"]
         assert partition_transform_bucket_count == 5
         tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
         assert tblproperties["table_type"] == "ICEBERG"
@@ -1642,8 +1634,8 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
                 "col_partition_truncate_1",
                 types.String,
                 awsathena_partition=True,
-                awsathena_partition_transform='truncate',
-                awsathena_partition_transform_truncate_length=5
+                awsathena_partition_transform="truncate",
+                awsathena_partition_transform_truncate_length=5,
             ),
             awsathena_location=f"{ENV.s3_staging_dir}{ENV.schema}/{table_name}/",
             awsathena_tblproperties={"table_type": "ICEBERG"},
@@ -1671,12 +1663,13 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
         assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
         assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
         assert actual.c.col_partition_truncate_1.dialect_options["awsathena"]["partition"]
-        partition_transform = \
-            actual.c.col_partition_truncate_1.dialect_options["awsathena"]["partition_transform"]
-        assert partition_transform == 'truncate'
-        partition_transform_truncate_length = \
-            actual.c.col_partition_truncate_1.\
-            dialect_options["awsathena"]["partition_transform_truncate_length"]
+        partition_transform = actual.c.col_partition_truncate_1.dialect_options["awsathena"][
+            "partition_transform"
+        ]
+        assert partition_transform == "truncate"
+        partition_transform_truncate_length = actual.c.col_partition_truncate_1.dialect_options[
+            "awsathena"
+        ]["partition_transform_truncate_length"]
         assert partition_transform_truncate_length == 5
         tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
         assert tblproperties["table_type"] == "ICEBERG"

--- a/tests/pyathena/sqlalchemy/test_base.py
+++ b/tests/pyathena/sqlalchemy/test_base.py
@@ -1310,10 +1310,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             )
             """
         )
-        assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
-        assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
-        assert actual.c.col_partition_1.dialect_options["awsathena"]["partition"]
-        assert actual.c.col_partition_2.dialect_options["awsathena"]["partition"]
+
         tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
         assert tblproperties["table_type"] == "ICEBERG"
 
@@ -1387,7 +1384,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             f"""
             CREATE TABLE {ENV.schema}.{table_name} (
             \tcol_1 STRING,
-            \tcol_2 INT
+            \tcol_2 INT,
             \tdt DATE
             )
             PARTITIONED BY (
@@ -1399,9 +1396,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             )
             """
         )
-        assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
-        assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
-        assert actual.c.dt.dialect_options["awsathena"]["partition"]
+
         tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
         assert tblproperties["table_type"] == "ICEBERG"
 
@@ -1427,7 +1422,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             f"""
             CREATE TABLE {ENV.schema}.{table_name} (
             \tcol_1 STRING,
-            \tcol_2 INT
+            \tcol_2 INT,
             \tdt DATE
             )
             PARTITIONED BY (
@@ -1439,10 +1434,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             )
             """
         )
-        assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
-        assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
-        assert actual.c.dt.dialect_options["awsathena"]["partition"]
-        assert actual.c.dt.dialect_options["awsathena"]["partition_transform"] == "year"
+
         tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
         assert tblproperties["table_type"] == "ICEBERG"
 
@@ -1468,7 +1460,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             f"""
             CREATE TABLE {ENV.schema}.{table_name} (
             \tcol_1 STRING,
-            \tcol_2 INT
+            \tcol_2 INT,
             \tdt DATE
             )
             PARTITIONED BY (
@@ -1480,10 +1472,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             )
             """
         )
-        assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
-        assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
-        assert actual.c.dt.dialect_options["awsathena"]["partition"]
-        assert actual.c.dt.dialect_options["awsathena"]["partition_transform"] == "month"
+
         tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
         assert tblproperties["table_type"] == "ICEBERG"
 
@@ -1507,7 +1496,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             f"""
             CREATE TABLE {ENV.schema}.{table_name} (
             \tcol_1 STRING,
-            \tcol_2 INT
+            \tcol_2 INT,
             \tdt DATE
             )
             PARTITIONED BY (
@@ -1519,10 +1508,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             )
             """
         )
-        assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
-        assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
-        assert actual.c.dt.dialect_options["awsathena"]["partition"]
-        assert actual.c.dt.dialect_options["awsathena"]["partition_transform"] == "day"
+
         tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
         assert tblproperties["table_type"] == "ICEBERG"
 
@@ -1551,7 +1537,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             f"""
             CREATE TABLE {ENV.schema}.{table_name} (
             \tcol_1 STRING,
-            \tcol_2 INT
+            \tcol_2 INT,
             \tts TIMESTAMP
             )
             PARTITIONED BY (
@@ -1563,10 +1549,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             )
             """
         )
-        assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
-        assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
-        assert actual.c.ts.dialect_options["awsathena"]["partition"]
-        assert actual.c.ts.dialect_options["awsathena"]["partition_transform"] == "hour"
+
         tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
         assert tblproperties["table_type"] == "ICEBERG"
 
@@ -1596,7 +1579,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             f"""
             CREATE TABLE {ENV.schema}.{table_name} (
             \tcol_1 STRING,
-            \tcol_2 INT
+            \tcol_2 INT,
             \tcol_partition_bucket_1 INT
             )
             PARTITIONED BY (
@@ -1608,17 +1591,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             )
             """
         )
-        assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
-        assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
-        assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition"]
-        partition_transform = actual.c.col_partition_bucket_1.dialect_options["awsathena"][
-            "partition_transform"
-        ]
-        assert partition_transform == "bucket"
-        partition_transform_bucket_count = actual.c.col_partition_bucket_1.dialect_options[
-            "awsathena"
-        ]["partition_transform_bucket_count"]
-        assert partition_transform_bucket_count == 5
+
         tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
         assert tblproperties["table_type"] == "ICEBERG"
 
@@ -1648,7 +1621,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             f"""
             CREATE TABLE {ENV.schema}.{table_name} (
             \tcol_1 STRING,
-            \tcol_2 INT
+            \tcol_2 INT,
             \tcol_partition_truncate_1
             )
             PARTITIONED BY (
@@ -1660,17 +1633,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             )
             """
         )
-        assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
-        assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
-        assert actual.c.col_partition_truncate_1.dialect_options["awsathena"]["partition"]
-        partition_transform = actual.c.col_partition_truncate_1.dialect_options["awsathena"][
-            "partition_transform"
-        ]
-        assert partition_transform == "truncate"
-        partition_transform_truncate_length = actual.c.col_partition_truncate_1.dialect_options[
-            "awsathena"
-        ]["partition_transform_truncate_length"]
-        assert partition_transform_truncate_length == 5
+
         tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
         assert tblproperties["table_type"] == "ICEBERG"
 

--- a/tests/pyathena/sqlalchemy/test_base.py
+++ b/tests/pyathena/sqlalchemy/test_base.py
@@ -1620,7 +1620,7 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
                 CREATE TABLE {ENV.schema}.{table_name} (
                 \tcol_1 STRING,
                 \tcol_2 INT
-                \tcol_partition_bucket_1 STRING
+                \tcol_partition_truncate_1
                 )
                 PARTITIONED BY (
                 \ttruncate(5, col_partition_truncate_1)
@@ -1633,9 +1633,9 @@ OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
             )
             assert not actual.c.col_1.dialect_options["awsathena"]["partition"]
             assert not actual.c.col_2.dialect_options["awsathena"]["partition"]
-            assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition"]
-            assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition_transform"] == 'truncate'
-            assert actual.c.col_partition_bucket_1.dialect_options["awsathena"]["partition_transform_truncate_length"] == 5
+            assert actual.c.col_partition_truncate_1.dialect_options["awsathena"]["partition"]
+            assert actual.c.col_partition_truncate_1.dialect_options["awsathena"]["partition_transform"] == 'truncate'
+            assert actual.c.col_partition_truncate_1.dialect_options["awsathena"]["partition_transform_truncate_length"] == 5
             tblproperties = actual.dialect_options["awsathena"]["tblproperties"]
             assert tblproperties["table_type"] == "ICEBERG"
 

--- a/tests/pyathena/test_model.py
+++ b/tests/pyathena/test_model.py
@@ -398,6 +398,7 @@ class TestAthenaCompression:
         assert not AthenaCompression.is_valid("")
         assert not AthenaCompression.is_valid("foobar")
 
+
 class TestAthenaPartitionTransform:
     def test_is_valid(self):
         assert AthenaCompression.is_valid("year")

--- a/tests/pyathena/test_model.py
+++ b/tests/pyathena/test_model.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pyathena.model import (
     AthenaCompression,
     AthenaFileFormat,
+    AthenaPartitionTransform,
     AthenaQueryExecution,
     AthenaRowFormatSerde,
     AthenaTableMetadata,
@@ -401,17 +402,17 @@ class TestAthenaCompression:
 
 class TestAthenaPartitionTransform:
     def test_is_valid(self):
-        assert AthenaCompression.is_valid("year")
-        assert AthenaCompression.is_valid("YEAR")
-        assert AthenaCompression.is_valid("month")
-        assert AthenaCompression.is_valid("MONTH")
-        assert AthenaCompression.is_valid("day")
-        assert AthenaCompression.is_valid("DAY")
-        assert AthenaCompression.is_valid("hour")
-        assert AthenaCompression.is_valid("HOUR")
-        assert AthenaCompression.is_valid("bucket")
-        assert AthenaCompression.is_valid("BUCKET")
-        assert AthenaCompression.is_valid("truncate")
-        assert AthenaCompression.is_valid("TRUNCATE")
-        assert not AthenaCompression.is_valid("")
-        assert not AthenaCompression.is_valid("foobar")
+        assert AthenaPartitionTransform.is_valid("year")
+        assert AthenaPartitionTransform.is_valid("YEAR")
+        assert AthenaPartitionTransform.is_valid("month")
+        assert AthenaPartitionTransform.is_valid("MONTH")
+        assert AthenaPartitionTransform.is_valid("day")
+        assert AthenaPartitionTransform.is_valid("DAY")
+        assert AthenaPartitionTransform.is_valid("hour")
+        assert AthenaPartitionTransform.is_valid("HOUR")
+        assert AthenaPartitionTransform.is_valid("bucket")
+        assert AthenaPartitionTransform.is_valid("BUCKET")
+        assert AthenaPartitionTransform.is_valid("truncate")
+        assert AthenaPartitionTransform.is_valid("TRUNCATE")
+        assert not AthenaPartitionTransform.is_valid("")
+        assert not AthenaPartitionTransform.is_valid("foobar")

--- a/tests/pyathena/test_model.py
+++ b/tests/pyathena/test_model.py
@@ -397,3 +397,20 @@ class TestAthenaCompression:
         assert AthenaCompression.is_valid("SNAPPY")
         assert not AthenaCompression.is_valid("")
         assert not AthenaCompression.is_valid("foobar")
+
+class TestAthenaPartitionTransform:
+    def test_is_valid(self):
+        assert AthenaCompression.is_valid("year")
+        assert AthenaCompression.is_valid("YEAR")
+        assert AthenaCompression.is_valid("month")
+        assert AthenaCompression.is_valid("MONTH")
+        assert AthenaCompression.is_valid("day")
+        assert AthenaCompression.is_valid("DAY")
+        assert AthenaCompression.is_valid("hour")
+        assert AthenaCompression.is_valid("HOUR")
+        assert AthenaCompression.is_valid("bucket")
+        assert AthenaCompression.is_valid("BUCKET")
+        assert AthenaCompression.is_valid("truncate")
+        assert AthenaCompression.is_valid("TRUNCATE")
+        assert not AthenaCompression.is_valid("")
+        assert not AthenaCompression.is_valid("foobar")


### PR DESCRIPTION
Solves https://github.com/laughingman7743/PyAthena/issues/458, started from #459.

I adapted the handling of the column dialect option 'partition' in _prepared_columns() for ICEBERG tables.
I also added three column dialect options.

"partition_transform" - pass partition transform function
"partition_transform_bucket_count" - pass bucket count for partition transform function 'bucket'
"partition_transform_truncate_length" - pass truncate length for partition transform function 'truncate'
All partition functions are defined in model.py under AthenaPartitionTransform.

There are tests for the ICEBERG partitions and each partition transform, as well as for AthenaPartitionTransform.

I did not add handlers for the connect options for those column dialect options.
Also did not update the README.