### PR TITLE
support json

### DIFF
--- a/pyathena/sqlalchemy/base.py
+++ b/pyathena/sqlalchemy/base.py
@@ -418,6 +418,8 @@ class AthenaStatementCompiler(SQLCompiler):
             type_clause = "CHAR"
         elif isinstance(cast.type, (types.BINARY, types.VARBINARY)):
             type_clause = "VARBINARY"
+        elif isinstance(cast.type, types.JSON):
+            type_clause = "JSON"
         else:
             type_clause = cast.typeclause._compiler_dispatch(self, **kwargs)
         return f"CAST({cast.clause._compiler_dispatch(self, **kwargs)} AS {type_clause})"
@@ -506,6 +508,9 @@ class AthenaTypeCompiler(GenericTypeCompiler):
 
     def visit_BOOLEAN(self, type_: Type[Any], **kw) -> str:
         return "BOOLEAN"
+
+    def visit_JSON(self, type_: Type[Any], **kw) -> str:
+        return "JSON"
 
     def visit_string(self, type_, **kw):
         return "STRING"

--- a/pyathena/sqlalchemy/pandas.py
+++ b/pyathena/sqlalchemy/pandas.py
@@ -1,11 +1,21 @@
 # -*- coding: utf-8 -*-
 from pyathena.sqlalchemy.base import AthenaDialect
 from pyathena.util import strtobool
+import json
 
 
 class AthenaPandasDialect(AthenaDialect):
     driver = "pandas"
     supports_statement_cache = True
+
+    @staticmethod
+    def json_try_deserialize(x):
+        try:
+            return json.loads(x)
+        except:
+            return x
+
+    _json_deserializer = json_try_deserialize
 
     def create_connect_args(self, url):
         from pyathena.pandas.cursor import PandasCursor


### PR DESCRIPTION
This to support JSON in pyathena

Example use case 

```python
# table
class TestTable(Base):
    __tablename__ = "my_test_table"
    # this table has a column that is of Iceberg Array format
	my_test_column: Mapped[Union[list[str], None]] = mapped_column(ARRAY(String))


# query
def query_table(cursor):
	q = select(
            func.cast(TestTable.my_test_column, JSON).label(
                "my_test_column"
            )
        )
	x = q.compile(
            session.bind,
            session.bind.dialect,
            compile_kwargs={"render_postcompile": True},
        )
	df = cursor.execute(str(x), parameters=x.params, na_values=[]).as_pandas()
	return df
```