### PR TITLE
Enhances Cursor type inference capabilities

### DIFF
--- a/pyathena/__init__.py
+++ b/pyathena/__init__.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 import datetime
 from typing import TYPE_CHECKING, Any, FrozenSet, Type, overload
 
-from pyathena.connection import ConnectionCursor
-from pyathena.cursor import Cursor
 from pyathena.error import *  # noqa
 
 if TYPE_CHECKING:
-    from pyathena.connection import Connection
+    from pyathena.connection import Connection, ConnectionCursor
+    from pyathena.cursor import Cursor
 
 __version__ = "3.1.0"
 user_agent_extra: str = f"PyAthena/{__version__}"

--- a/pyathena/__init__.py
+++ b/pyathena/__init__.py
@@ -2,8 +2,10 @@
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING, Any, FrozenSet, Type
+from typing import TYPE_CHECKING, Any, FrozenSet, Type, overload
 
+from pyathena.connection import ConnectionCursor
+from pyathena.cursor import Cursor
 from pyathena.error import *  # noqa
 
 if TYPE_CHECKING:
@@ -55,6 +57,18 @@ JSON: DBAPITypeObject = DBAPITypeObject(("json",))
 Date: Type[datetime.date] = datetime.date
 Time: Type[datetime.time] = datetime.time
 Timestamp: Type[datetime.datetime] = datetime.datetime
+
+
+@overload
+def connect(*args, cursor_class: None = ..., **kwargs) -> "Connection[Cursor]":
+    ...
+
+
+@overload
+def connect(
+    *args, cursor_class: Type[ConnectionCursor], **kwargs
+) -> "Connection[ConnectionCursor]":
+    ...
 
 
 def connect(*args, **kwargs) -> "Connection[Any]":

--- a/pyathena/__init__.py
+++ b/pyathena/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING, FrozenSet, Type
+from typing import TYPE_CHECKING, Any, FrozenSet, Type
 
 from pyathena.error import *  # noqa
 
@@ -57,7 +57,7 @@ Time: Type[datetime.time] = datetime.time
 Timestamp: Type[datetime.datetime] = datetime.datetime
 
 
-def connect(*args, **kwargs) -> "Connection":
+def connect(*args, **kwargs) -> "Connection[Any]":
     from pyathena.connection import Connection
 
     return Connection(*args, **kwargs)

--- a/pyathena/arrow/result_set.py
+++ b/pyathena/arrow/result_set.py
@@ -51,7 +51,7 @@ class AthenaArrowResultSet(AthenaResultSet):
 
     def __init__(
         self,
-        connection: "Connection",
+        connection: "Connection[Any]",
         converter: Converter,
         query_execution: AthenaQueryExecution,
         arraysize: int,

--- a/pyathena/common.py
+++ b/pyathena/common.py
@@ -97,7 +97,7 @@ class BaseCursor(metaclass=ABCMeta):
 
     def __init__(
         self,
-        connection: "Connection",
+        connection: "Connection[Any]",
         converter: Converter,
         formatter: Formatter,
         retry_config: RetryConfig,
@@ -134,7 +134,7 @@ class BaseCursor(metaclass=ABCMeta):
         return DefaultTypeConverter()
 
     @property
-    def connection(self) -> "Connection":
+    def connection(self) -> "Connection[Any]":
         return self._connection
 
     def _build_start_query_execution_request(

--- a/pyathena/connection.py
+++ b/pyathena/connection.py
@@ -254,7 +254,9 @@ class Connection(Generic[ConnectionCursor]):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
-    def cursor(self, cursor: Optional[Type[FunctionalCursor]] = None, **kwargs) -> Union[FunctionalCursor, ConnectionCursor]:
+    def cursor(
+        self, cursor: Optional[Type[FunctionalCursor]] = None, **kwargs
+    ) -> Union[FunctionalCursor, ConnectionCursor]:
         kwargs.update(self.cursor_kwargs)
         if cursor:
             _cursor = cursor

--- a/pyathena/connection.py
+++ b/pyathena/connection.py
@@ -4,7 +4,19 @@ from __future__ import annotations
 import logging
 import os
 import time
-from typing import TYPE_CHECKING, Any, Dict, Generic, List, Optional, Type, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Generic,
+    List,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
 
 from boto3.session import Session
 from botocore.config import Config
@@ -50,6 +62,68 @@ class Connection(Generic[ConnectionCursor]):
         "config",
     ]
 
+    @overload
+    def __init__(
+        self: Connection[Cursor],
+        s3_staging_dir: Optional[str] = ...,
+        region_name: Optional[str] = ...,
+        schema_name: Optional[str] = ...,
+        catalog_name: Optional[str] = ...,
+        work_group: Optional[str] = ...,
+        poll_interval: float = ...,
+        encryption_option: Optional[str] = ...,
+        kms_key: Optional[str] = ...,
+        profile_name: Optional[str] = ...,
+        role_arn: Optional[str] = ...,
+        role_session_name: str = ...,
+        external_id: Optional[str] = ...,
+        serial_number: Optional[str] = ...,
+        duration_seconds: int = ...,
+        converter: Optional[Converter] = ...,
+        formatter: Optional[Formatter] = ...,
+        retry_config: Optional[RetryConfig] = ...,
+        cursor_class: None = ...,
+        cursor_kwargs: Optional[Dict[str, Any]] = ...,
+        kill_on_interrupt: bool = ...,
+        session: Optional[Session] = ...,
+        config: Optional[Config] = ...,
+        result_reuse_enable: bool = ...,
+        result_reuse_minutes: int = ...,
+        **kwargs,
+    ) -> None:
+        ...
+
+    @overload
+    def __init__(
+        self: Connection[FunctionalCursor],
+        s3_staging_dir: Optional[str] = ...,
+        region_name: Optional[str] = ...,
+        schema_name: Optional[str] = ...,
+        catalog_name: Optional[str] = ...,
+        work_group: Optional[str] = ...,
+        poll_interval: float = ...,
+        encryption_option: Optional[str] = ...,
+        kms_key: Optional[str] = ...,
+        profile_name: Optional[str] = ...,
+        role_arn: Optional[str] = ...,
+        role_session_name: str = ...,
+        external_id: Optional[str] = ...,
+        serial_number: Optional[str] = ...,
+        duration_seconds: int = ...,
+        converter: Optional[Converter] = ...,
+        formatter: Optional[Formatter] = ...,
+        retry_config: Optional[RetryConfig] = ...,
+        cursor_class: Type[ConnectionCursor] = ...,
+        cursor_kwargs: Optional[Dict[str, Any]] = ...,
+        kill_on_interrupt: bool = ...,
+        session: Optional[Session] = ...,
+        config: Optional[Config] = ...,
+        result_reuse_enable: bool = ...,
+        result_reuse_minutes: int = ...,
+        **kwargs,
+    ) -> None:
+        ...
+
     def __init__(
         self,
         s3_staging_dir: Optional[str] = None,
@@ -69,7 +143,7 @@ class Connection(Generic[ConnectionCursor]):
         converter: Optional[Converter] = None,
         formatter: Optional[Formatter] = None,
         retry_config: Optional[RetryConfig] = None,
-        cursor_class: Type[ConnectionCursor] = Cursor,
+        cursor_class: Optional[Type[ConnectionCursor]] = cast(Type[ConnectionCursor], Cursor),
         cursor_kwargs: Optional[Dict[str, Any]] = None,
         kill_on_interrupt: bool = True,
         session: Optional[Session] = None,
@@ -162,7 +236,7 @@ class Connection(Generic[ConnectionCursor]):
         self._converter = converter
         self._formatter = formatter if formatter else DefaultParameterFormatter()
         self._retry_config = retry_config if retry_config else RetryConfig()
-        self.cursor_class = cursor_class
+        self.cursor_class = cast(Type[ConnectionCursor], cursor_class)
         self.cursor_kwargs = cursor_kwargs if cursor_kwargs else dict()
         self.kill_on_interrupt = kill_on_interrupt
         self.result_reuse_enable = result_reuse_enable
@@ -254,14 +328,19 @@ class Connection(Generic[ConnectionCursor]):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
+    @overload
+    def cursor(self, cursor: None = ..., **kwargs) -> ConnectionCursor:
+        ...
+
+    @overload
+    def cursor(self, cursor: Type[FunctionalCursor], **kwargs) -> FunctionalCursor:
+        ...
+
     def cursor(
         self, cursor: Optional[Type[FunctionalCursor]] = None, **kwargs
     ) -> Union[FunctionalCursor, ConnectionCursor]:
         kwargs.update(self.cursor_kwargs)
-        if cursor:
-            _cursor = cursor
-        else:
-            _cursor = self.cursor_class
+        _cursor = cursor or self.cursor_class
         converter = kwargs.pop("converter", self._converter)
         if not converter:
             converter = _cursor.get_default_converter(kwargs.get("unload", False))

--- a/pyathena/connection.py
+++ b/pyathena/connection.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 import os
 import time
-from typing import TYPE_CHECKING, Any, Dict, Generic, List, Optional, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, Generic, List, Optional, Type, TypeVar, Union
 
 from boto3.session import Session
 from botocore.config import Config
@@ -254,7 +254,7 @@ class Connection(Generic[ConnectionCursor]):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
-    def cursor(self, cursor: Optional[Type[FunctionalCursor]] = None, **kwargs):
+    def cursor(self, cursor: Optional[Type[FunctionalCursor]] = None, **kwargs) -> Union[FunctionalCursor, ConnectionCursor]:
         kwargs.update(self.cursor_kwargs)
         if cursor:
             _cursor = cursor

--- a/pyathena/connection.py
+++ b/pyathena/connection.py
@@ -95,7 +95,7 @@ class Connection(Generic[ConnectionCursor]):
 
     @overload
     def __init__(
-        self: Connection[FunctionalCursor],
+        self: Connection[ConnectionCursor],
         s3_staging_dir: Optional[str] = ...,
         region_name: Optional[str] = ...,
         schema_name: Optional[str] = ...,

--- a/pyathena/filesystem/s3.py
+++ b/pyathena/filesystem/s3.py
@@ -38,7 +38,7 @@ class S3FileSystem(AbstractFileSystem):
 
     def __init__(
         self,
-        connection: Optional["Connection"] = None,
+        connection: Optional["Connection[Any]"] = None,
         default_block_size: Optional[int] = None,
         default_cache_type: Optional[str] = None,
         max_workers: int = (cpu_count() or 1) * 5,

--- a/pyathena/pandas/result_set.py
+++ b/pyathena/pandas/result_set.py
@@ -100,7 +100,7 @@ class AthenaPandasResultSet(AthenaResultSet):
 
     def __init__(
         self,
-        connection: "Connection",
+        connection: "Connection[Any]",
         converter: Converter,
         query_execution: AthenaQueryExecution,
         arraysize: int,

--- a/pyathena/pandas/util.py
+++ b/pyathena/pandas/util.py
@@ -135,7 +135,7 @@ def to_parquet(
 def to_sql(
     df: "DataFrame",
     name: str,
-    conn: "Connection",
+    conn: "Connection[Any]",
     location: str,
     schema: str = "default",
     index: bool = False,

--- a/pyathena/result_set.py
+++ b/pyathena/result_set.py
@@ -33,14 +33,14 @@ _logger = logging.getLogger(__name__)  # type: ignore
 class AthenaResultSet(CursorIterator):
     def __init__(
         self,
-        connection: "Connection",
+        connection: "Connection[Any]",
         converter: Converter,
         query_execution: AthenaQueryExecution,
         arraysize: int,
         retry_config: RetryConfig,
     ) -> None:
         super().__init__(arraysize=arraysize)
-        self._connection: Optional["Connection"] = connection
+        self._connection: Optional["Connection[Any]"] = connection
         self._converter = converter
         self._query_execution: Optional[AthenaQueryExecution] = query_execution
         assert self._query_execution, "Required argument `query_execution` not found."
@@ -280,10 +280,10 @@ class AthenaResultSet(CursorIterator):
         ]
 
     @property
-    def connection(self) -> "Connection":
+    def connection(self) -> "Connection[Any]":
         if self.is_closed:
             raise ProgrammingError("AthenaResultSet is closed.")
-        return cast("Connection", self._connection)
+        return cast("Connection[Any]", self._connection)
 
     def __fetch(self, next_token: Optional[str] = None) -> Dict[str, Any]:
         if not self.query_id:


### PR DESCRIPTION
# Related Issue
- #484

# Overview
Enhances type inference capabilities. While there may be no significant impact in some use cases, it is better compared to before.

# Use Case
```python
connection = Connection() # -> pyathena.connection.Connection[pyathena.cursor.Cursor]
connection_cursor = connection.cursor() # -> pyathena.cursor.Cursor

async_connection = Connection(cursor_class=AsyncCursor) # -> pyathena.connection.Connection[pyathena.async_cursor.AsyncCursor]
async_connection_cursor = async_connection.cursor() # -> pyathena.async_cursor.AsyncCursor
dict_cursor = async_connection.cursor(DictCursor) # -> (pyathena.async_cursor.AsyncCursor | pyathena.cursor.DictCursor) (IDE seems to be pretty confusing)

factory_connection = connect(cursor_class=AsyncCursor) # -> pyathena.connection.Connection (factory can't be inferred)
factory_connection_cursor = factory_connection.cursor() # -> Any (factory can't be inferred)
factory_connection_functional_cursor = factory_connection.cursor(DictCursor) # -> pyathena.cursor.DictCursor
```

# Limitation
- using a mix of multiple cursor is inferred a union of cursor types
- `def connection` factory method still not support type hint