### PR TITLE
Add support for UPDATE and MERGE operation in formatter

### DIFF
--- a/pyathena/formatter.py
+++ b/pyathena/formatter.py
@@ -184,6 +184,8 @@ class DefaultParameterFormatter(Formatter):
             operation_upper.startswith("SELECT")
             or operation_upper.startswith("WITH")
             or operation_upper.startswith("INSERT")
+            or operation_upper.startswith("UPDATE")
+            or operation_upper.startswith("MERGE")
         ):
             escaper = _escape_presto
         else:


### PR DESCRIPTION
Currently the formatter doesn't escape single quotes when the operation is MERGE or UPDATE. With this change MERGE and UPDATE update operations will be formatted with the _escape_presto instead of _escape_hive