### PR TITLE
Trace S3 GET requests back to Athena queries.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing
+
+This project uses [`hatch`](https://hatch.pypa.io/latest/) to manage building, running, and testing.
+
+Install `hatch` with `pip install hatch` then use the commands in the `Makefile`.
+
+To build the wheel locally, use `hatch build`.

--- a/pyathena/__init__.py
+++ b/pyathena/__init__.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from pyathena.connection import Connection, ConnectionCursor
     from pyathena.cursor import Cursor
 
-__version__ = "3.8.3"
+__version__ = "3.8.4+tonybeta"
 user_agent_extra: str = f"PyAthena/{__version__}"
 
 # Globals https://www.python.org/dev/peps/pep-0249/#globals

--- a/pyathena/common.py
+++ b/pyathena/common.py
@@ -572,11 +572,10 @@ class BaseCursor(metaclass=ABCMeta):
             cache_expiration_time=cache_expiration_time if cache_expiration_time else 0,
         )
         if query_id is None:
-            client_request_token = str(uuid4())
+            query_trace_id = str(uuid4())
             old_user_agent_extra = self._connection.client._client_config.user_agent_extra
             try:
-                request['ClientRequestToken'] = client_request_token
-                self._connection.client._client_config.user_agent_extra += f' ClientRequestToken={client_request_token}'
+                self._connection.client._client_config.user_agent_extra += f' QueryTraceId={query_trace_id}'
 
                 try:
                     query_id = retry_api_call(


### PR DESCRIPTION
https://github.com/dbt-athena/dbt-athena/issues/686

Context here is if you are spending a large amount of money on S3 GET requests it can be quite difficult to track down exactly which query is originating the requests. Yes, you can get pretty close with:

- Checking IAM identity in S3 GET CloudTrail log.
- Checking User-Agent in S3 GET CloudTrail log.
- S3 bucket metric filters.

But these are all quite indirect. Instead I propose injecting some unique identifier into the User-Agent header for each StartQueryExecution call. That way, the User-Agent string now uniquely identifies a StartQueryExecution request _and_ will be passed along to the GetObject requests, allowing us to associate GetObject requests with specific query executions.

Yes, this is janky as shit and not really a smart way of doing it and just generally probably considered _ab_use of the User-Agent header.... but there doesn't seem to really be another alternative so....

You can use the User-Agent and responseElements of the CloudTrail log line for the StartQueryExecution call to associate the GETs with an Athena QueryExecutionId, which can in turn be used to look up the QueryText (not incuded in CloudTrail logs, instead available from athena:GetQueryExecution).

TODO:

- test?