### PR TITLE
Allow the use of use_fips_endpoint arg for client connections

### DIFF
--- a/pyathena/connection.py
+++ b/pyathena/connection.py
@@ -60,6 +60,7 @@ class Connection(Generic[ConnectionCursor]):
         "endpoint_url",
         "region_name",
         "config",
+        "use_fips_endpoint",
     ]
 
     @overload


### PR DESCRIPTION
`boto3.client(..., use_fips_endpoint=True)` tells the Boto3 client to prioritize using FIPS 140-2 compliant endpoints.

The `use_fips_endpoint` parameter in the Python AWS client (Boto3) setup controls whether the client will communicate with Federal Information Processing Standards (FIPS) 140-2 compliant endpoints.
FIPS endpoints are AWS service endpoints that utilize FIPS 140-2 validated cryptographic modules for encrypting data in transit. This ensures a higher level of security and compliance for sensitive workloads.
If your application needs to comply with FIPS 140-2 standards (often required for U.S. federal government agencies and organizations working with them), you must use FIPS endpoints.

This PR allows this parameter to be set when needed.

See: `Amazon Athena` in https://aws.amazon.com/compliance/fips/ 

