### PR TITLE
Fix dynamic imports in SQLAlchemy dialect components

### DIFF
--- a/pyathena/sqlalchemy/base.py
+++ b/pyathena/sqlalchemy/base.py
@@ -22,6 +22,7 @@ import botocore
 from sqlalchemy import exc, schema, text, types, util
 from sqlalchemy.engine import Engine, reflection
 from sqlalchemy.engine.default import DefaultDialect
+from sqlalchemy.engine.interfaces import ExecutionContext
 from sqlalchemy.sql.compiler import (
     DDLCompiler,
     GenericTypeCompiler,
@@ -378,17 +379,12 @@ class AthenaDialect(DefaultDialect):
         return []  # pragma: no cover
 
     def do_execute(self, cursor, statement, parameters, context=None):
-        """Execute a statement with support for execution_options."""
-        from sqlalchemy.engine.interfaces import ExecutionContext
-
-        # Check for on_start_query_execution in execution_options
         on_start_query_execution = None
         if isinstance(context, ExecutionContext):
             execution_options = context.execution_options
             if execution_options is not None:
                 on_start_query_execution = execution_options.get("on_start_query_execution")
 
-        # Execute with callback if specified
         if on_start_query_execution is not None:
             cursor.execute(statement, parameters, on_start_query_execution=on_start_query_execution)
         else:

--- a/pyathena/sqlalchemy/compiler.py
+++ b/pyathena/sqlalchemy/compiler.py
@@ -18,6 +18,7 @@ from pyathena.model import (
     AthenaPartitionTransform,
     AthenaRowFormatSerde,
 )
+from pyathena.sqlalchemy.preparer import AthenaDDLIdentifierPreparer
 from pyathena.sqlalchemy.types import AthenaArray, AthenaMap, AthenaStruct
 
 if TYPE_CHECKING:
@@ -271,8 +272,6 @@ class AthenaDDLCompiler(DDLCompiler):
         render_schema_translate: bool = False,
         compile_kwargs: Optional[Dict[str, Any]] = None,
     ):
-        from pyathena.sqlalchemy.preparer import AthenaDDLIdentifierPreparer
-
         self._preparer = AthenaDDLIdentifierPreparer(dialect)
         super().__init__(
             dialect=dialect,


### PR DESCRIPTION
## Summary
- Remove runtime imports from `do_execute` method in `AthenaDialect`
- Remove runtime imports from `__init__` method in `AthenaDDLCompiler`  
- Move imports to top-level as required by PyAthena development guidelines

## Changes
- **pyathena/sqlalchemy/base.py**: Move `ExecutionContext` import to top-level, remove dynamic import from `do_execute`
- **pyathena/sqlalchemy/compiler.py**: Move `AthenaDDLIdentifierPreparer` import to top-level, remove dynamic import from `__init__`

## Benefits
- Improves static analysis and code completion
- Better dependency tracking
- Follows PyAthena coding guidelines that prohibit runtime imports
- Maintains full functionality while improving code quality

## Test plan
- [x] All quality checks pass (`make chk`)
- [x] Linting: ✅ ruff check
- [x] Formatting: ✅ ruff format --check  
- [x] Type checking: ✅ mypy

🤖 Generated with [Claude Code](https://claude.ai/code)