### PR TITLE
Introduce hatch-vcs for automatic version management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ cover/
 docs/_build
 .mcp.json
 .serena
+_version.py

--- a/pyathena/__init__.py
+++ b/pyathena/__init__.py
@@ -10,7 +10,15 @@ if TYPE_CHECKING:
     from pyathena.connection import Connection, ConnectionCursor
     from pyathena.cursor import Cursor
 
-__version__ = "3.17.1"
+try:
+    from pyathena._version import __version__
+except ImportError:
+    try:
+        from importlib.metadata import version
+
+        __version__ = version("PyAthena")
+    except Exception:
+        __version__ = "unknown"
 user_agent_extra: str = f"PyAthena/{__version__}"
 
 # Globals https://www.python.org/dev/peps/pep-0249/#globals

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.hatch.metadata]
@@ -82,7 +82,10 @@ only-include = [
 packages = ["pyathena"]
 
 [tool.hatch.version]
-path = "pyathena/__init__.py"
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "pyathena/_version.py"
 
 [tool.pytest.ini_options]
 norecursedirs = [

--- a/uv.lock
+++ b/uv.lock
@@ -806,7 +806,6 @@ wheels = [
 
 [[package]]
 name = "pyathena"
-version = "3.12.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

This PR introduces [hatch-vcs](https://github.com/ofek/hatch-vcs) to automate version management using Git tags, eliminating the need for manual version bump commits.

## Changes

- **Add hatch-vcs dependency**: Added to `build-system.requires` in `pyproject.toml`
- **Configure VCS version source**: Set `tool.hatch.version.source = "vcs"` to read versions from Git tags
- **Add VCS build hook**: Configure `tool.hatch.build.hooks.vcs` to generate `_version.py` during build
- **Update version handling**: Modified `pyathena/__init__.py` to use generated version file with robust fallbacks:
  1. Try to import from generated `_version.py` (primary)
  2. Fallback to `importlib.metadata.version()` for installed packages
  3. Final fallback to `"unknown"` for safety

## Benefits

- ✅ **No more manual version bump commits** (addresses #588)
- ✅ **Git tag-based releases**: Version automatically derived from Git tags
- ✅ **Development builds**: Automatic versioning with commit info (e.g., `3.17.2.dev0+g134a94a.d20250816`)
- ✅ **Robust fallbacks**: Works in all environments (development, installed, built packages)
- ✅ **Existing workflow compatibility**: No changes needed to `.github/workflows/release.yaml`

## Version Examples

- **Tagged release**: `v3.17.1` → `3.17.1`
- **Development**: `3.17.2.dev0+g134a94a.d20250816`
- **Installed package**: Retrieved from package metadata

## Testing

- [x] Quality checks pass (`make chk`)
- [x] Version detection works correctly
- [x] Build process generates proper `_version.py`
- [x] Fallback mechanisms function as expected

## Migration

After merging, the workflow becomes:
1. Create Git tag (e.g., `git tag v3.17.2`)
2. Push tag (`git push origin v3.17.2`)
3. GitHub Actions automatically builds and releases
4. No manual version editing required

Resolves #588

🤖 Generated with [Claude Code](https://claude.ai/code)