### PR TITLE
`'NoneType' object has no attribute 'get'` can happen on AWS retries

### DIFF
--- a/tests/pyathena/test_util.py
+++ b/tests/pyathena/test_util.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
+from typing import Any
+
 import pytest
 
 from pyathena import DataError
-from pyathena.util import parse_output_location, strtobool
+from pyathena.util import RetryConfig, parse_output_location, retry_api_call, strtobool
 
 
 def test_parse_output_location():
@@ -25,3 +27,38 @@ def test_strtobool():
 
     for n in no:
         assert not strtobool(n)
+
+
+class _WithCodeError(Exception):
+    def __init__(self, code: int) -> None:
+        super().__init__(f"error:{code}")
+        self.response = {"Error": {"Code": code}}
+
+
+class _NoResponseError(Exception):
+    def __init__(self) -> None:
+        super().__init__("error")
+        self.response = None
+
+
+def _test_retry(ex: Exception) -> None:
+    calls = {"n": 0}
+
+    def fn() -> Any:
+        calls["n"] += 1
+        raise ex
+
+    cfg = RetryConfig(attempt=1, max_delay=1)
+
+    with pytest.raises(type(ex)):
+        retry_api_call(fn, config=cfg)
+
+    assert calls["n"] == 1
+
+
+def test_retry_api_call():
+    _test_retry(_WithCodeError(500))
+
+
+def test_retry_api_call_with_none_error():
+    _test_retry(_NoResponseError())


### PR DESCRIPTION
## What

When using the library with Superset on pages with many charts, likely hammering the Athena API, we're seeing transient errors that often go away on a page refresh after caching:
```
pyathena.error.DatabaseError: 'NoneType' object has no attribute 'get'
```

Full stack trace:
```
File "/app/.venv/lib/python3.10/site-packages/pyathena/util.py", line 69, in <lambda>
    lambda e: getattr(e, "response", {}).get("Error", {}).get("Code") in config.exceptions
AttributeError: 'NoneType' object has no attribute 'get'

File "/app/.venv/lib/python3.10/site-packages/tenacity/__init__.py", line 360, in _run_retry
    result = action(retry_state)

File "/app/.venv/lib/python3.10/site-packages/tenacity/__init__.py", line 378, in iter
    do = self.iter(retry_state=retry_state)

File "/app/.venv/lib/python3.10/site-packages/pyathena/util.py", line 82, in retry_api_call
    query_id = retry_api_call(...)

File "/app/.venv/lib/python3.10/site-packages/pyathena/common.py", line 584, in _execute
    self.query_id = self._execute(...)

File "/app/.venv/lib/python3.10/site-packages/pyathena/pandas/cursor.py", line 187, in execute
    cursor.execute(query)

File "/app/superset/db_engine_specs/base.py", line 1864, in execute
    raise cls.get_dbapi_mapped_exception(ex) from ex

File "/app/superset/models/core.py", line 706, in get_df
    df = self.database.get_df(...)

File "/app/superset/connectors/sqla/models.py", line 1748, in query
    ...
```

**I am unsure in which cases it's possible to get a `None` response, but this PR makes this a bit more defensive.**
### Runtime Metadata

- **Environment**: K8s/EKS
- **Image**: `apachesuperset:5.0.0`
- **Version**:
	- `pyathena[pandas]`: "3.17.1"
	- `PyAthenaJDBC`: "3.0.1"

## Fix

While I don't know why this is sometimes happening, this should be more defensive/safe.

## Test
Added unit tests, 

```bash

uv pip install -r pyproject.toml --all-extra
export AWS_DEFAULT_REGION=us-west-2
export AWS_ATHENA_S3_STAGING_DIR=s3://YOUR_S3_BUCKET/path/to/
export AWS_ATHENA_WORKGROUP=pyathena
export AWS_ATHENA_SPARK_WORKGROUP=pyathena-spark
pytest --noconftest -vv -s tests/pyathena/test_util.py -k test_retry_api_call

```

Before:
```
FAILED tests/pyathena/test_util.py::test_retry_api_call - AttributeError: 'NoneType' object has no attribute 'get'
```

After the change, it passes.

I also deployed my feature branch to our Superset environment and haven't seen the error since.


## Notes

Not sure if you love nested/anonymous functions, there wasn't a lint rule against it. It's a bit awkward in general, since we can't really rely on the types.