### PR TITLE
Fix: Correct engine fixture usage in test_reserved_words

### DIFF
--- a/tests/pyathena/sqlalchemy/test_base.py
+++ b/tests/pyathena/sqlalchemy/test_base.py
@@ -361,6 +361,7 @@ class TestSQLAlchemyAthena:
 
     def test_reserved_words(self, engine):
         """Presto uses double quotes, not backticks"""
+        engine, conn = engine
         fake_table = Table("bernoulli", MetaData(), Column("current_catalog", types.String()))
         query = (
             fake_table.select()


### PR DESCRIPTION
## Summary
Fixes the CI failure introduced in #603 where `test_reserved_words` was calling `engine.dialect` on a tuple instead of the engine object.

## Problem
The `engine` fixture returns a tuple `(engine, conn)`, but the test was trying to access `engine.dialect` directly on the tuple, causing:
```
AttributeError: 'tuple' object has no attribute 'dialect'
```

## Solution
- Unpack the engine fixture tuple like other tests do: `engine, conn = engine`
- This follows the same pattern used in other tests like `test_select_offset_limit`

## Test Results
- ✅ Local test passes after the fix
- ✅ Follows existing code patterns in the test suite

🤖 Generated with [Claude Code](https://claude.ai/code)