### PR TITLE
Fix documentation version display

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for version detection
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - uses: astral-sh/setup-uv@v5
@@ -30,6 +32,7 @@ jobs:
           enable-cache: true
       - run: |
           uv sync --group dev
+          uv build
           make docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,3 +89,10 @@ html_static_path = ["_static"]
 html_css_files = [
     "custom.css",
 ]
+
+# Furo theme options
+html_theme_options = {
+    "source_repository": "https://github.com/laughingman7743/PyAthena/",
+    "source_branch": "master",
+    "source_directory": "docs/",
+}


### PR DESCRIPTION
## Summary

Fixes the documentation version display issue where the docs showed incorrect version strings like `v0.1.dev1+gf45815e0` instead of the correct version.

## Problem

The documentation was showing `PyAthena v0.1.dev1+gf45815e0` because:
1. GitHub Actions checkout was using shallow clone (no git history/tags)
2. `pyathena/_version.py` was not being generated by hatch-vcs during docs build
3. The version detection in `docs/conf.py` fell through to "unknown"

## Solution

### 1. Fetch Full Git History
```yaml
- name: Checkout
  uses: actions/checkout@v4
  with:
    fetch-depth: 0  # Fetch all history for version detection
```

### 2. Build Package Before Docs
```yaml
- run: |
    uv sync --group dev
    uv build  # Generate _version.py with hatch-vcs
    make docs
```

This allows hatch-vcs to:
- Read git tags (e.g., `v3.18.0`)
- Calculate commits since tag (e.g., 7 commits)
- Generate proper dev version: `v3.18.1.dev7+g8bf8d8582.d20251018`

### 3. Add Furo Theme Options
Added source repository configuration to `docs/conf.py` for better navigation.

## Before vs After

**Before**: `PyAthena v0.1.dev1+gf45815e0 documentation`  
**After**: `PyAthena v3.18.1.dev7+g8bf8d8582.d20251018 documentation`

## Testing

Tested locally with:
```bash
uv build
make docs
```

The generated HTML shows the correct version in the title and sidebar.

## Related Issues

Fixes #607

## Notes

- Version selector implementation will be addressed in a future PR (requires sphinx-multiversion)
- The `_version.py` file is auto-generated during build and not tracked in git

🤖 Generated with [Claude Code](https://claude.com/claude-code)