### PR TITLE
fix: Correct version selector to show current version as selected

### DIFF
--- a/docs/_templates/versioning.html
+++ b/docs/_templates/versioning.html
@@ -4,8 +4,8 @@
   <div class="version-dropdown" style="margin-bottom: 1rem;">
     <select onchange="window.location.href = this.value" style="width: 100%; padding: 0.5rem; border: 1px solid var(--color-background-border); border-radius: 0.25rem; background-color: var(--color-background-secondary); color: var(--color-foreground-primary); font-size: var(--font-size--small); cursor: pointer;">
       {% for item in versions %}
-      <option value="{{ item.url }}" {% if item.name == current_version %}selected{% endif %}>
-        {{ item.name }}{% if item.name == current_version %} (current){% endif %}
+      <option value="{{ item.url }}" {% if item == current_version %}selected{% endif %}>
+        {{ item.name }}{% if item == current_version %} (current){% endif %}
       </option>
       {% endfor %}
     </select>


### PR DESCRIPTION
## Problem

The version selector dropdown was not showing the current version as selected. For example:
- When viewing `v3.12.2/index.html`, the dropdown did not have v3.12.2 selected
- When viewing `master/index.html`, the dropdown did not have master selected

## Root Cause

The template was comparing `item.name == current_version`, which compared a string with an object. The `current_version` provided by sphinx-multiversion is a version object, not a string.

## Solution

Changed the comparison from `item.name == current_version` to `item == current_version` to properly compare version objects.

## Verification

Tested locally:
- ✅ v3.12.2 page now shows v3.12.2 as `selected` in dropdown
- ✅ master page now shows master as `selected` in dropdown

## Changes

- Updated `docs/_templates/versioning.html` to use correct version object comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)