### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - name: Checkout
@@ -32,13 +32,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
-      # TODO: In the case of Python 3.13, the following error occurs, so install Python using setup-python.
+      # TODO: In the case of Python 3.13+, the following error occurs, so install Python using setup-python.
       #   ../meson.build:44:2: ERROR: Problem encountered: Cannot compile
       #   `Python.h`. Perhaps you need to install python-dev|python-devel
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-        if: matrix.python-version == '3.13'
+        if: matrix.python-version == '3.13' || matrix.python-version == '3.14'
       - run: |
           make tool
 

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Requirements
 
 * Python
 
-  - CPython 3.9 3.10, 3.11 3.12 3.13
+  - CPython 3.9 3.10, 3.11 3.12 3.13 3.14
 
 .. _installation:
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -10,7 +10,7 @@ Requirements
 
 * Python
 
-  - CPython 3.9 3.10, 3.11 3.12 3.13
+  - CPython 3.9 3.10, 3.11 3.12 3.13 3.14
 
 .. _installation:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dynamic = ["version"]
 
@@ -149,7 +150,7 @@ exclude = [
 legacy_tox_ini = """
 [tox]
 isolated_build = true
-envlist = py{39,310,311,312,313}
+envlist = py{39,310,311,312,313,314}
 
 [gh-actions]
 python =
@@ -158,6 +159,7 @@ python =
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314
 
 [testenv]
 allowlist_externals =


### PR DESCRIPTION
## Summary
Add official support for Python 3.14, which was released on October 7, 2025.

## Changes
- Add `Programming Language :: Python :: 3.14` classifier in pyproject.toml
- Add `py314` to tox envlist
- Add `3.14: py314` to gh-actions mapping
- Add Python 3.14 to CI test matrix
- Apply setup-python workaround for Python 3.14 (similar to Python 3.13 meson.build issue)
- Update Python version requirements in README.rst and docs/introduction.rst

## Test Plan
- [ ] CI tests pass on Python 3.14
- [ ] All dependencies are compatible with Python 3.14
- [ ] No deprecation warnings or compatibility issues

## References
- Closes #615
- [PEP 745 – Python 3.14 Release Schedule](https://peps.python.org/pep-0745/)
- [Python 3.14.0 Release](https://www.python.org/downloads/release/python-3140/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)