### PR TITLE
trailing slash check for s3_staging_dir

### DIFF
--- a/pyathena/connection.py
+++ b/pyathena/connection.py
@@ -261,7 +261,10 @@ class Connection(Generic[ConnectionCursor]):
         assert self.s3_staging_dir or self.work_group, (
             "Required argument `s3_staging_dir` or `work_group` not found."
         )
-
+        
+        if self.s3_staging_dir and not self.s3_staging_dir.endswith("/"):
+            self.s3_staging_dir = f"{self.s3_staging_dir}/"
+        
         if session:
             self._session = session
         else:


### PR DESCRIPTION
If the trailing slash isn't there, Athena throws a generic error:

[ErrorCode: INTERNAL_ERROR_QUERY_ENGINE] Amazon Athena experienced an internal error while executing this query. Please contact AWS support for further assistance. You will not be charged for this query. We apologize for the inconvenience.