### PR TITLE
Add S3FSCursor and AsyncS3FSCursor to cursor documentation page

### DIFF
--- a/docs/cursor.rst
+++ b/docs/cursor.rst
@@ -319,6 +319,19 @@ AsyncArrowCursor
 
 See :ref:`async-arrow-cursor`.
 
+S3FSCursor
+----------
+
+See :ref:`s3fs-cursor`.
+
+AsyncS3FSCursor
+---------------
+
+See :ref:`async-s3fs-cursor`.
+
+API Reference
+-------------
+
 SparkCursor
 -----------
 
@@ -329,10 +342,7 @@ AsyncSparkCursor
 
 See :ref:`async-spark-cursor`.
 
-API Reference
--------------
-
-For detailed API documentation of all cursor classes and their methods, 
+For detailed API documentation of all cursor classes and their methods,
 see the :ref:`api` section.
 
 .. _`DB API 2.0 (PEP 249)`: https://www.python.org/dev/peps/pep-0249/


### PR DESCRIPTION
## Summary
- Add references to S3FSCursor and AsyncS3FSCursor in the cursor.rst documentation page

## Problem
The cursor.rst page lists all available cursor types with references to their detailed documentation, but S3FSCursor and AsyncS3FSCursor were missing despite having detailed documentation in s3fs.rst.

## Changes
- Added S3FSCursor section with reference to `:ref:`s3fs-cursor``
- Added AsyncS3FSCursor section with reference to `:ref:`async-s3fs-cursor``

🤖 Generated with [Claude Code](https://claude.com/claude-code)