### PR TITLE
Unify _to_date converter and add git workflow guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,15 @@ The project supports different cursor implementations for various use cases:
 
 ## Development Guidelines
 
+### Git Workflow
+
+**CRITICAL: Never Commit Directly to Master Branch**
+- **NEVER** commit directly to the `master` branch
+- **ALWAYS** create a feature branch for any changes
+- **ALWAYS** create a Pull Request (PR) for review
+- Use descriptive branch names (e.g., `feature/add-converter`, `fix/null-handling`)
+- Create PRs as drafts using `gh pr create --draft`
+
 ### Code Style and Quality
 
 #### Import Guidelines

--- a/pyathena/arrow/converter.py
+++ b/pyathena/arrow/converter.py
@@ -2,14 +2,13 @@
 from __future__ import annotations
 
 import logging
-from builtins import isinstance
 from copy import deepcopy
-from datetime import date, datetime
-from typing import Any, Callable, Dict, Optional, Type, Union
+from typing import Any, Callable, Dict, Optional, Type
 
 from pyathena.converter import (
     Converter,
     _to_binary,
+    _to_date,
     _to_decimal,
     _to_default,
     _to_json,
@@ -17,14 +16,6 @@ from pyathena.converter import (
 )
 
 _logger = logging.getLogger(__name__)  # type: ignore
-
-
-def _to_date(value: Optional[Union[str, datetime]]) -> Optional[date]:
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value.date()
-    return datetime.strptime(value, "%Y-%m-%d").date()
 
 
 _DEFAULT_ARROW_CONVERTERS: Dict[str, Callable[[Optional[str]], Optional[Any]]] = {

--- a/pyathena/converter.py
+++ b/pyathena/converter.py
@@ -8,7 +8,7 @@ from abc import ABCMeta, abstractmethod
 from copy import deepcopy
 from datetime import date, datetime, time
 from decimal import Decimal
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 from dateutil.tz import gettz
 
@@ -17,10 +17,14 @@ from pyathena.util import strtobool
 _logger = logging.getLogger(__name__)  # type: ignore
 
 
-def _to_date(varchar_value: Optional[str]) -> Optional[date]:
-    if varchar_value is None:
+def _to_date(value: Optional[Union[str, datetime, date]]) -> Optional[date]:
+    if value is None:
         return None
-    return datetime.strptime(varchar_value, "%Y-%m-%d").date()
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    return datetime.strptime(value, "%Y-%m-%d").date()
 
 
 def _to_datetime(varchar_value: Optional[str]) -> Optional[datetime]:

--- a/pyathena/polars/converter.py
+++ b/pyathena/polars/converter.py
@@ -3,28 +3,18 @@ from __future__ import annotations
 
 import logging
 from copy import deepcopy
-from datetime import date, datetime
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional
 
 from pyathena.converter import (
     Converter,
     _to_binary,
+    _to_date,
     _to_default,
     _to_json,
     _to_time,
 )
 
 _logger = logging.getLogger(__name__)
-
-
-def _to_date(value: Optional[Union[str, datetime, date]]) -> Optional[date]:
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value.date()
-    if isinstance(value, date):
-        return value
-    return datetime.strptime(value, "%Y-%m-%d").date()
 
 
 _DEFAULT_POLARS_CONVERTERS: Dict[str, Callable[[Optional[str]], Optional[Any]]] = {


### PR DESCRIPTION
## Summary

- Extended base `_to_date` function to handle `Union[str, datetime, date]`
- Removed duplicate `_to_date` implementations from arrow and polars converters
- Added git workflow guidelines to CLAUDE.md

## Changes

- `pyathena/converter.py`: Extended `_to_date` to accept datetime and date objects
- `pyathena/arrow/converter.py`: Removed duplicate `_to_date`, now imports from base
- `pyathena/polars/converter.py`: Removed duplicate `_to_date`, now imports from base
- `CLAUDE.md`: Added Git Workflow section with branch protection guidelines

## Test plan

- [x] `make chk` passes (lint, format, type check)
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)