### PR TITLE
Pass WorkGroup parameter to GetTableMetadata and ListTableMetadata APIs

### DIFF
--- a/pyathena/common.py
+++ b/pyathena/common.py
@@ -308,6 +308,8 @@ class BaseCursor(metaclass=ABCMeta):
         }
         if next_token:
             request.update({"NextToken": next_token})
+        if self._work_group:
+            request.update({"WorkGroup": self._work_group})
         return request
 
     def _list_databases(


### PR DESCRIPTION
## Summary
- Added `WorkGroup` parameter to `GetTableMetadata` API call
- Added `WorkGroup` parameter to `ListTableMetadata` API call
- Added `WorkGroup` parameter to `ListDatabases` API call

When using PyAthena with a configured `work_group`, these metadata API calls now include the `WorkGroup` parameter. This allows IAM policies to use specific workgroup ARNs instead of wildcards, improving security posture.

This is particularly important for IAM Identity Center enabled Glue Data Catalogs where the WorkGroup parameter is required.

## Changes
- `_get_table_metadata()`: Now includes `WorkGroup` in the request when `self._work_group` is set
- `_build_list_table_metadata_request()`: Now includes `WorkGroup` in the request when `self._work_group` is set
- `_build_list_databases_request()`: Now includes `WorkGroup` in the request when `self._work_group` is set

## Test plan
- CI tests should pass
- Manual testing can verify CloudTrail shows `workGroup` parameter in API calls

Fixes #645