### PR TITLE
Fix retry_api_call to use getEffectiveLevel() instead of logger.level

### DIFF
--- a/pyathena/util.py
+++ b/pyathena/util.py
@@ -190,7 +190,7 @@ def retry_api_call(
             max=config.max_delay,
             exp_base=config.exponential_base,
         ),
-        after=after_log(logger, logger.level) if logger else None,  # type: ignore
+        after=after_log(logger, logger.getEffectiveLevel()) if logger else None,  # type: ignore
         reraise=True,
     )
     return retry(func, *args, **kwargs)


### PR DESCRIPTION
## Summary
- Fix `retry_api_call` in `pyathena/util.py` to use `logger.getEffectiveLevel()` instead of `logger.level`
- `logger.level` returns `0` (NOTSET) when no level is explicitly set on the logger, causing `after_log` retry logs to be silently dropped
- `getEffectiveLevel()` correctly walks the logger hierarchy and returns the inherited level

Closes #649

## Test plan
- [ ] Verify `make chk` passes (lint, format, type check)
- [ ] Set `logging.getLogger("pyathena").setLevel(logging.DEBUG)` and confirm retry logs are now visible without needing to set level on `pyathena.common` directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)