### PR TITLE
Fix README logo not displaying on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-<img src="docs/_static/icon.png" alt="PyAthena logo" width="250">
+<img src="https://raw.githubusercontent.com/laughingman7743/PyAthena/master/docs/_static/icon.png" alt="PyAthena logo" width="250">
 
 [![PyPI - Version](https://badge.fury.io/py/pyathena.svg)](https://badge.fury.io/py/pyathena)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/PyAthena.svg)](https://pypi.org/project/PyAthena/)


### PR DESCRIPTION
## Summary
- Use absolute URL (`raw.githubusercontent.com`) for the README logo image
- PyPI cannot resolve relative paths like `docs/_static/icon.png`, so the logo was not displayed on the [PyPI page](https://pypi.org/project/PyAthena/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)