### PR TITLE
Update documentation domain to pyathena.dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ tox:
 docs:
 	uv run sphinx-multiversion docs docs/_build/html
 	echo '<meta http-equiv="refresh" content="0; url=./master/index.html">' > docs/_build/html/index.html
+	echo 'pyathena.dev' > docs/_build/html/CNAME
 	touch docs/_build/html/.nojekyll
 
 .PHONY: tool

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Many of the implementations in this library are based on [PyHive](https://github
 
 ## Links
 
-- Documentation: https://pyathena-dev.github.io/PyAthena/
+- Documentation: https://pyathena.dev/
 - PyPI Releases: https://pypi.org/project/PyAthena/
 - Source Code: https://github.com/pyathena-dev/PyAthena/
 - Issue Tracker: https://github.com/pyathena-dev/PyAthena/issues

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -207,8 +207,8 @@ html_sidebars = {
 
 # -- Open Graph protocol settings ----------------------------------------------
 
-ogp_site_url = "https://pyathena-dev.github.io/PyAthena/"
-ogp_image = "https://pyathena-dev.github.io/PyAthena/_static/ogp_white.png"
+ogp_site_url = "https://pyathena.dev/"
+ogp_image = "https://pyathena.dev/_static/ogp_white.png"
 ogp_description_length = 200
 ogp_type = "website"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dynamic = ["version"]
 [project.urls]
 homepage = "https://github.com/pyathena-dev/PyAthena/"
 repository = "https://github.com/pyathena-dev/PyAthena/"
-documentation = "https://pyathena-dev.github.io/PyAthena/"
+documentation = "https://pyathena.dev/"
 issues = "https://github.com/pyathena-dev/PyAthena/issues"
 
 [project.entry-points."sqlalchemy.dialects"]


### PR DESCRIPTION
## Summary
- Migrate all documentation URLs from `pyathena-dev.github.io/PyAthena` to the custom domain `pyathena.dev`
- Generate `CNAME` file during docs build to ensure custom domain persists across GitHub Pages deployments
- Update Open Graph meta tags, PyPI project URLs, and README links

## Changes
| File | Change |
|------|--------|
| `docs/conf.py` | Update `ogp_site_url` and `ogp_image` URLs |
| `pyproject.toml` | Update `project.urls.documentation` |
| `README.md` | Update documentation link |
| `Makefile` | Add CNAME file generation to `make docs` |

## Test plan
- [ ] Verify `pyathena.dev` resolves to GitHub Pages
- [ ] Verify HTTPS works correctly
- [ ] After merge, confirm `make docs` generates CNAME file in build output
- [ ] Verify Open Graph tags show correct URL on social sharing

🤖 Generated with [Claude Code](https://claude.com/claude-code)