### PR TITLE
Extract shared boilerplate from sync cursors into WithFetch mixin

### DIFF
--- a/pyathena/async_cursor.py
+++ b/pyathena/async_cursor.py
@@ -7,8 +7,7 @@ from concurrent.futures.thread import ThreadPoolExecutor
 from multiprocessing import cpu_count
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
-from pyathena.common import CursorIterator
-from pyathena.cursor import BaseCursor
+from pyathena.common import BaseCursor, CursorIterator
 from pyathena.error import NotSupportedError, ProgrammingError
 from pyathena.model import AthenaQueryExecution
 from pyathena.result_set import AthenaDictResultSet, AthenaResultSet

--- a/pyathena/cursor.py
+++ b/pyathena/cursor.py
@@ -2,17 +2,17 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Union, cast
 
-from pyathena.common import BaseCursor, CursorIterator
+from pyathena.common import CursorIterator
 from pyathena.error import OperationalError, ProgrammingError
 from pyathena.model import AthenaQueryExecution
-from pyathena.result_set import AthenaDictResultSet, AthenaResultSet, WithResultSet
+from pyathena.result_set import AthenaDictResultSet, AthenaResultSet, WithFetch
 
 _logger = logging.getLogger(__name__)  # type: ignore
 
 
-class Cursor(BaseCursor, CursorIterator, WithResultSet):
+class Cursor(WithFetch):
     """A DB API 2.0 compliant cursor for executing SQL queries on Amazon Athena.
 
     The Cursor class provides methods for executing SQL queries against Amazon Athena
@@ -68,84 +68,20 @@ class Cursor(BaseCursor, CursorIterator, WithResultSet):
             result_reuse_minutes=result_reuse_minutes,
             **kwargs,
         )
-        self._query_id: Optional[str] = None
-        self._result_set: Optional[AthenaResultSet] = None
         self._result_set_class = AthenaResultSet
         self._on_start_query_execution = on_start_query_execution
 
     @property
-    def result_set(self) -> Optional[AthenaResultSet]:
-        """Get the result set from the last executed query.
+    def arraysize(self) -> int:
+        return self._arraysize
 
-        Returns:
-            The result set object containing query results, or None if no
-            query has been executed or the query didn't return results.
-        """
-        return self._result_set
-
-    @result_set.setter
-    def result_set(self, val) -> None:
-        """Set the result set for the cursor.
-
-        Args:
-            val: The result set object to assign.
-        """
-        self._result_set = val
-
-    @property
-    def query_id(self) -> Optional[str]:
-        """Get the Athena query execution ID of the last executed query.
-
-        Returns:
-            The query execution ID assigned by Athena, or None if no query
-            has been executed.
-        """
-        return self._query_id
-
-    @query_id.setter
-    def query_id(self, val) -> None:
-        """Set the Athena query execution ID.
-
-        Args:
-            val: The query execution ID to set.
-        """
-        self._query_id = val
-
-    @property
-    def rownumber(self) -> Optional[int]:
-        """Get the current row number within the result set.
-
-        Returns:
-            The zero-based index of the current row, or None if no result set
-            is available or no rows have been fetched.
-        """
-        return self.result_set.rownumber if self.result_set else None
-
-    @property
-    def rowcount(self) -> int:
-        """Get the number of rows affected by the last operation.
-
-        For SELECT statements, this returns the total number of rows in the
-        result set. For other operations, behavior follows DB API 2.0 specification.
-
-        Returns:
-            The number of rows, or -1 if not applicable or unknown.
-        """
-        return self.result_set.rowcount if self.result_set else -1
-
-    def close(self) -> None:
-        """Close the cursor and free any associated resources.
-
-        Closes the cursor and any associated result sets. This method is provided
-        for DB API 2.0 compatibility and should be called when the cursor is no
-        longer needed.
-
-        Note:
-            After calling this method, the cursor should not be used for
-            further database operations.
-        """
-        if self.result_set and not self.result_set.is_closed:
-            self.result_set.close()
+    @arraysize.setter
+    def arraysize(self, value: int) -> None:
+        if value <= 0 or value > self.DEFAULT_FETCH_SIZE:
+            raise ProgrammingError(
+                f"MaxResults is more than maximum allowed length {self.DEFAULT_FETCH_SIZE}."
+            )
+        self._arraysize = value
 
     def execute(
         self,
@@ -218,155 +154,6 @@ class Cursor(BaseCursor, CursorIterator, WithResultSet):
         else:
             raise OperationalError(query_execution.state_change_reason)
         return self
-
-    def executemany(
-        self,
-        operation: str,
-        seq_of_parameters: List[Optional[Union[Dict[str, Any], List[str]]]],
-        **kwargs,
-    ) -> None:
-        """Execute a SQL query multiple times with different parameters.
-
-        This method executes the same SQL operation multiple times, once for each
-        parameter set in the sequence. This is useful for bulk operations like
-        inserting multiple rows.
-
-        Args:
-            operation: SQL query string to execute.
-            seq_of_parameters: Sequence of parameter dictionaries or lists, one for each execution.
-            **kwargs: Additional keyword arguments passed to each execute() call.
-
-        Note:
-            This method executes each query sequentially. For better performance
-            with bulk operations, consider using batch operations where supported.
-            Operations that return result sets are not allowed with executemany.
-
-        Example:
-            >>> cursor.executemany(
-            ...     "INSERT INTO users (id, name) VALUES (%(id)s, %(name)s)",
-            ...     [
-            ...         {"id": 1, "name": "Alice"},
-            ...         {"id": 2, "name": "Bob"},
-            ...         {"id": 3, "name": "Charlie"}
-            ...     ]
-            ... )
-        """
-        for parameters in seq_of_parameters:
-            self.execute(operation, parameters, **kwargs)
-        # Operations that have result sets are not allowed with executemany.
-        self._reset_state()
-
-    def cancel(self) -> None:
-        """Cancel the currently executing query.
-
-        Cancels the query execution on Amazon Athena. This method can be called
-        from a different thread to interrupt a long-running query.
-
-        Raises:
-            ProgrammingError: If no query is currently executing (query_id is None).
-
-        Example:
-            >>> import threading
-            >>> import time
-            >>>
-            >>> def cancel_after_delay():
-            ...     time.sleep(5)  # Wait 5 seconds
-            ...     cursor.cancel()
-            >>>
-            >>> # Start cancellation in separate thread
-            >>> threading.Thread(target=cancel_after_delay).start()
-            >>> cursor.execute("SELECT * FROM very_large_table")
-        """
-        if not self.query_id:
-            raise ProgrammingError("QueryExecutionId is none or empty.")
-        self._cancel(self.query_id)
-
-    def fetchone(
-        self,
-    ) -> Optional[Union[Tuple[Optional[Any], ...], Dict[Any, Optional[Any]]]]:
-        """Fetch the next row of a query result set.
-
-        Returns the next row of the query result as a tuple, or None when
-        no more data is available. Column values are converted to appropriate
-        Python types based on the Athena data types.
-
-        Returns:
-            A tuple representing the next row, or None if no more rows.
-
-        Raises:
-            ProgrammingError: If called before executing a query that returns results.
-
-        Example:
-            >>> cursor.execute("SELECT id, name FROM users LIMIT 3")
-            >>> while True:
-            ...     row = cursor.fetchone()
-            ...     if not row:
-            ...         break
-            ...     print(f"ID: {row[0]}, Name: {row[1]}")
-        """
-        if not self.has_result_set:
-            raise ProgrammingError("No result set.")
-        result_set = cast(AthenaResultSet, self.result_set)
-        return result_set.fetchone()
-
-    def fetchmany(
-        self, size: Optional[int] = None
-    ) -> List[Union[Tuple[Optional[Any], ...], Dict[Any, Optional[Any]]]]:
-        """Fetch multiple rows from a query result set.
-
-        Returns up to 'size' rows from the query result as a list of tuples.
-        If size is not specified, uses the cursor's arraysize attribute.
-
-        Args:
-            size: Maximum number of rows to fetch. If None, uses arraysize.
-
-        Returns:
-            List of tuples representing the fetched rows. May contain fewer
-            rows than requested if fewer are available.
-
-        Raises:
-            ProgrammingError: If called before executing a query that returns results.
-
-        Example:
-            >>> cursor.execute("SELECT id, name FROM users")
-            >>> rows = cursor.fetchmany(5)  # Fetch up to 5 rows
-            >>> for row in rows:
-            ...     print(f"ID: {row[0]}, Name: {row[1]}")
-        """
-        if not self.has_result_set:
-            raise ProgrammingError("No result set.")
-        result_set = cast(AthenaResultSet, self.result_set)
-        return result_set.fetchmany(size)
-
-    def fetchall(
-        self,
-    ) -> List[Union[Tuple[Optional[Any], ...], Dict[Any, Optional[Any]]]]:
-        """Fetch all remaining rows from a query result set.
-
-        Returns all remaining rows from the query result as a list of tuples.
-        For large result sets, consider using fetchmany() or iterating with
-        fetchone() to avoid memory issues.
-
-        Returns:
-            List of tuples representing all remaining rows in the result set.
-
-        Raises:
-            ProgrammingError: If called before executing a query that returns results.
-
-        Example:
-            >>> cursor.execute("SELECT id, name FROM users WHERE active = true")
-            >>> all_rows = cursor.fetchall()
-            >>> print(f"Found {len(all_rows)} active users")
-            >>> for row in all_rows:
-            ...     print(f"ID: {row[0]}, Name: {row[1]}")
-
-        Warning:
-            Be cautious with large result sets as this loads all data into memory.
-        """
-        if not self.has_result_set:
-            raise ProgrammingError("No result set.")
-        result_set = cast(AthenaResultSet, self.result_set)
-        return result_set.fetchall()
 
 
 class DictCursor(Cursor):

--- a/pyathena/result_set.py
+++ b/pyathena/result_set.py
@@ -18,7 +18,7 @@ from typing import (
     cast,
 )
 
-from pyathena.common import CursorIterator
+from pyathena.common import BaseCursor, CursorIterator
 from pyathena.converter import Converter, DefaultTypeConverter
 from pyathena.error import DataError, OperationalError, ProgrammingError
 from pyathena.model import AthenaQueryExecution
@@ -898,3 +898,139 @@ class WithResultSet:
             The number of rows, or -1 if not applicable or unknown.
         """
         return self.result_set.rowcount if self.result_set else -1
+
+
+class WithFetch(BaseCursor, CursorIterator, WithResultSet):
+    """Mixin providing shared properties, fetch, lifecycle, and sync iteration for SQL cursors.
+
+    Provides properties (``arraysize``, ``result_set``, ``query_id``,
+    ``rownumber``, ``rowcount``), lifecycle methods (``close``, ``executemany``,
+    ``cancel``), default sync fetch (for cursors whose result sets load all
+    data eagerly in ``__init__``), and the sync iteration protocol.
+
+    Subclasses override ``execute()`` and optionally ``__init__`` and
+    format-specific helpers.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._query_id: Optional[str] = None
+        self._result_set: Optional[AthenaResultSet] = None
+
+    @property
+    def arraysize(self) -> int:
+        return self._arraysize
+
+    @arraysize.setter
+    def arraysize(self, value: int) -> None:
+        if value <= 0:
+            raise ProgrammingError("arraysize must be a positive integer value.")
+        self._arraysize = value
+
+    @property  # type: ignore
+    def result_set(self) -> Optional[AthenaResultSet]:
+        return self._result_set
+
+    @result_set.setter
+    def result_set(self, val) -> None:
+        self._result_set = val
+
+    @property
+    def query_id(self) -> Optional[str]:
+        return self._query_id
+
+    @query_id.setter
+    def query_id(self, val) -> None:
+        self._query_id = val
+
+    @property
+    def rownumber(self) -> Optional[int]:
+        return self.result_set.rownumber if self.result_set else None
+
+    @property
+    def rowcount(self) -> int:
+        return self.result_set.rowcount if self.result_set else -1
+
+    def close(self) -> None:
+        """Close the cursor and release associated resources."""
+        if self.result_set and not self.result_set.is_closed:
+            self.result_set.close()
+
+    def executemany(
+        self,
+        operation: str,
+        seq_of_parameters: List[Optional[Union[Dict[str, Any], List[str]]]],
+        **kwargs,
+    ) -> None:
+        """Execute a SQL query multiple times with different parameters.
+
+        Args:
+            operation: SQL query string to execute.
+            seq_of_parameters: Sequence of parameter sets, one per execution.
+            **kwargs: Additional keyword arguments passed to each ``execute()``.
+        """
+        for parameters in seq_of_parameters:
+            self.execute(operation, parameters, **kwargs)
+        # Operations that have result sets are not allowed with executemany.
+        self._reset_state()
+
+    def cancel(self) -> None:
+        """Cancel the currently executing query.
+
+        Raises:
+            ProgrammingError: If no query is currently executing.
+        """
+        if not self.query_id:
+            raise ProgrammingError("QueryExecutionId is none or empty.")
+        self._cancel(self.query_id)
+
+    def fetchone(
+        self,
+    ) -> Optional[Union[Tuple[Optional[Any], ...], Dict[Any, Optional[Any]]]]:
+        """Fetch the next row of the result set.
+
+        Returns:
+            A tuple representing the next row, or None if no more rows.
+
+        Raises:
+            ProgrammingError: If no result set is available.
+        """
+        if not self.has_result_set:
+            raise ProgrammingError("No result set.")
+        result_set = cast(AthenaResultSet, self.result_set)
+        return result_set.fetchone()
+
+    def fetchmany(
+        self, size: Optional[int] = None
+    ) -> List[Union[Tuple[Optional[Any], ...], Dict[Any, Optional[Any]]]]:
+        """Fetch multiple rows from the result set.
+
+        Args:
+            size: Maximum number of rows to fetch. Defaults to arraysize.
+
+        Returns:
+            List of tuples representing the fetched rows.
+
+        Raises:
+            ProgrammingError: If no result set is available.
+        """
+        if not self.has_result_set:
+            raise ProgrammingError("No result set.")
+        result_set = cast(AthenaResultSet, self.result_set)
+        return result_set.fetchmany(size)
+
+    def fetchall(
+        self,
+    ) -> List[Union[Tuple[Optional[Any], ...], Dict[Any, Optional[Any]]]]:
+        """Fetch all remaining rows from the result set.
+
+        Returns:
+            List of tuples representing all remaining rows.
+
+        Raises:
+            ProgrammingError: If no result set is available.
+        """
+        if not self.has_result_set:
+            raise ProgrammingError("No result set.")
+        result_set = cast(AthenaResultSet, self.result_set)
+        return result_set.fetchall()


### PR DESCRIPTION
## Summary

- Add `WithFetch` mixin to `pyathena/result_set.py` — the sync counterpart to `WithAsyncFetch` — consolidating shared properties (`arraysize`, `result_set`, `query_id`, `rownumber`, `rowcount`), lifecycle methods (`close()`, `executemany()`, `cancel()`), and fetch methods (`fetchone()`, `fetchmany()`, `fetchall()`) into a single base class
- Refactor `Cursor`, `PandasCursor`, `ArrowCursor`, `PolarsCursor`, and `S3FSCursor` to inherit from `WithFetch` instead of the triple `(BaseCursor, CursorIterator, WithResultSet)`, removing ~500 lines of duplicated code
- Fix `async_cursor.py` import to use canonical `pyathena.common.BaseCursor` path

## Design decisions

- **Placement in `result_set.py`**: Avoids circular import (`common.py` → `result_set.py` → `common.py`) since `result_set.py` already imports `CursorIterator` from `common.py`
- **Simple `arraysize` validation** (`value <= 0` only) in `WithFetch`, matching `WithAsyncFetch` — `Cursor` and `AioCursor` override with strict validation (`value > DEFAULT_FETCH_SIZE`)
- **Out of scope**: `SparkCursor` (different execution model), async cursors (separate concern), aio cursors (already deduplicated via `WithAsyncFetch`)

Closes #669

## Test plan

- [x] `make fmt` — formatting clean
- [x] `make chk` — ruff lint + mypy type checking pass
- [ ] `make test` — unit tests (requires AWS env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)