### PR TITLE
Extract _prepare_unload() helper into BaseCursor

### DIFF
--- a/pyathena/aio/arrow/cursor.py
+++ b/pyathena/aio/arrow/cursor.py
@@ -13,7 +13,7 @@ from pyathena.arrow.converter import (
 from pyathena.arrow.result_set import AthenaArrowResultSet
 from pyathena.common import CursorIterator
 from pyathena.error import OperationalError, ProgrammingError
-from pyathena.model import AthenaCompression, AthenaFileFormat, AthenaQueryExecution
+from pyathena.model import AthenaQueryExecution
 
 if TYPE_CHECKING:
     import polars as pl
@@ -110,18 +110,7 @@ class AioArrowCursor(WithAsyncFetch):
             Self reference for method chaining.
         """
         self._reset_state()
-        if self._unload:
-            s3_staging_dir = s3_staging_dir if s3_staging_dir else self._s3_staging_dir
-            if not s3_staging_dir:
-                raise ProgrammingError("If the unload option is used, s3_staging_dir is required.")
-            operation, unload_location = self._formatter.wrap_unload(
-                operation,
-                s3_staging_dir=s3_staging_dir,
-                format_=AthenaFileFormat.FILE_FORMAT_PARQUET,
-                compression=AthenaCompression.COMPRESSION_SNAPPY,
-            )
-        else:
-            unload_location = None
+        operation, unload_location = self._prepare_unload(operation, s3_staging_dir)
         self.query_id = await self._execute(
             operation,
             parameters=parameters,

--- a/pyathena/aio/pandas/cursor.py
+++ b/pyathena/aio/pandas/cursor.py
@@ -18,7 +18,7 @@ from typing import (
 from pyathena.aio.common import WithAsyncFetch
 from pyathena.common import CursorIterator
 from pyathena.error import OperationalError, ProgrammingError
-from pyathena.model import AthenaCompression, AthenaFileFormat, AthenaQueryExecution
+from pyathena.model import AthenaQueryExecution
 from pyathena.pandas.converter import (
     DefaultPandasTypeConverter,
     DefaultPandasUnloadTypeConverter,
@@ -133,18 +133,7 @@ class AioPandasCursor(WithAsyncFetch):
             Self reference for method chaining.
         """
         self._reset_state()
-        if self._unload:
-            s3_staging_dir = s3_staging_dir if s3_staging_dir else self._s3_staging_dir
-            if not s3_staging_dir:
-                raise ProgrammingError("If the unload option is used, s3_staging_dir is required.")
-            operation, unload_location = self._formatter.wrap_unload(
-                operation,
-                s3_staging_dir=s3_staging_dir,
-                format_=AthenaFileFormat.FILE_FORMAT_PARQUET,
-                compression=AthenaCompression.COMPRESSION_SNAPPY,
-            )
-        else:
-            unload_location = None
+        operation, unload_location = self._prepare_unload(operation, s3_staging_dir)
         self.query_id = await self._execute(
             operation,
             parameters=parameters,

--- a/pyathena/aio/polars/cursor.py
+++ b/pyathena/aio/polars/cursor.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 from pyathena.aio.common import WithAsyncFetch
 from pyathena.common import CursorIterator
 from pyathena.error import OperationalError, ProgrammingError
-from pyathena.model import AthenaCompression, AthenaFileFormat, AthenaQueryExecution
+from pyathena.model import AthenaQueryExecution
 from pyathena.polars.converter import (
     DefaultPolarsTypeConverter,
     DefaultPolarsUnloadTypeConverter,
@@ -115,18 +115,7 @@ class AioPolarsCursor(WithAsyncFetch):
             Self reference for method chaining.
         """
         self._reset_state()
-        if self._unload:
-            s3_staging_dir = s3_staging_dir if s3_staging_dir else self._s3_staging_dir
-            if not s3_staging_dir:
-                raise ProgrammingError("If the unload option is used, s3_staging_dir is required.")
-            operation, unload_location = self._formatter.wrap_unload(
-                operation,
-                s3_staging_dir=s3_staging_dir,
-                format_=AthenaFileFormat.FILE_FORMAT_PARQUET,
-                compression=AthenaCompression.COMPRESSION_SNAPPY,
-            )
-        else:
-            unload_location = None
+        operation, unload_location = self._prepare_unload(operation, s3_staging_dir)
         self.query_id = await self._execute(
             operation,
             parameters=parameters,

--- a/pyathena/arrow/cursor.py
+++ b/pyathena/arrow/cursor.py
@@ -11,7 +11,7 @@ from pyathena.arrow.converter import (
 from pyathena.arrow.result_set import AthenaArrowResultSet
 from pyathena.common import CursorIterator
 from pyathena.error import OperationalError, ProgrammingError
-from pyathena.model import AthenaCompression, AthenaFileFormat, AthenaQueryExecution
+from pyathena.model import AthenaQueryExecution
 from pyathena.result_set import WithFetch
 
 if TYPE_CHECKING:
@@ -166,18 +166,7 @@ class ArrowCursor(WithFetch):
             >>> table = cursor.as_arrow()  # Returns Apache Arrow Table
         """
         self._reset_state()
-        if self._unload:
-            s3_staging_dir = s3_staging_dir if s3_staging_dir else self._s3_staging_dir
-            if not s3_staging_dir:
-                raise ProgrammingError("If the unload option is used, s3_staging_dir is required.")
-            operation, unload_location = self._formatter.wrap_unload(
-                operation,
-                s3_staging_dir=s3_staging_dir,
-                format_=AthenaFileFormat.FILE_FORMAT_PARQUET,
-                compression=AthenaCompression.COMPRESSION_SNAPPY,
-            )
-        else:
-            unload_location = None
+        operation, unload_location = self._prepare_unload(operation, s3_staging_dir)
         self.query_id = self._execute(
             operation,
             parameters=parameters,

--- a/pyathena/formatter.py
+++ b/pyathena/formatter.py
@@ -8,7 +8,7 @@ from abc import ABCMeta, abstractmethod
 from copy import deepcopy
 from datetime import date, datetime, timezone
 from decimal import Decimal
-from typing import Any, Callable, Dict, Optional, Type
+from typing import Any, Callable, Dict, Optional, Tuple, Type
 
 from pyathena.error import ProgrammingError
 from pyathena.model import AthenaCompression, AthenaFileFormat
@@ -86,7 +86,7 @@ class Formatter(metaclass=ABCMeta):
         s3_staging_dir: str,
         format_: str = AthenaFileFormat.FILE_FORMAT_PARQUET,
         compression: str = AthenaCompression.COMPRESSION_SNAPPY,
-    ):
+    ) -> Tuple[str, Optional[str]]:
         """Wrap a SELECT query with UNLOAD statement for high-performance result retrieval.
 
         Transforms SELECT or WITH queries into UNLOAD statements that export results

--- a/pyathena/polars/cursor.py
+++ b/pyathena/polars/cursor.py
@@ -17,7 +17,7 @@ from typing import (
 
 from pyathena.common import CursorIterator
 from pyathena.error import OperationalError, ProgrammingError
-from pyathena.model import AthenaCompression, AthenaFileFormat, AthenaQueryExecution
+from pyathena.model import AthenaQueryExecution
 from pyathena.polars.converter import (
     DefaultPolarsTypeConverter,
     DefaultPolarsUnloadTypeConverter,
@@ -191,18 +191,7 @@ class PolarsCursor(WithFetch):
             >>> df = cursor.as_polars()  # Returns Polars DataFrame
         """
         self._reset_state()
-        if self._unload:
-            s3_staging_dir = s3_staging_dir if s3_staging_dir else self._s3_staging_dir
-            if not s3_staging_dir:
-                raise ProgrammingError("If the unload option is used, s3_staging_dir is required.")
-            operation, unload_location = self._formatter.wrap_unload(
-                operation,
-                s3_staging_dir=s3_staging_dir,
-                format_=AthenaFileFormat.FILE_FORMAT_PARQUET,
-                compression=AthenaCompression.COMPRESSION_SNAPPY,
-            )
-        else:
-            unload_location = None
+        operation, unload_location = self._prepare_unload(operation, s3_staging_dir)
         self.query_id = self._execute(
             operation,
             parameters=parameters,


### PR DESCRIPTION
## Summary

- Extracts the duplicated UNLOAD preparation block (validate `s3_staging_dir`, wrap query via `Formatter.wrap_unload()`) into a single `_prepare_unload()` method on `BaseCursor`
- Replaces 9 identical copies of the block (3 sync, 3 async, 3 aio cursor files) with a one-liner call
- Adds return type annotation to `Formatter.wrap_unload()` to satisfy mypy

Net change: **+48 / -119 lines** (71 lines removed).

Closes #670

## Test plan

- [x] `make fmt` passes
- [x] `make chk` passes (ruff lint + format + mypy)
- [ ] `make test` passes (requires AWS credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)