### PR TITLE
feat: support newer GetQueryExecution response fields

### DIFF
--- a/pyathena/model.py
+++ b/pyathena/model.py
@@ -111,9 +111,13 @@ class AthenaQueryExecution:
         self._query_planning_time_in_millis: int | None = statistics.get(
             "QueryPlanningTimeInMillis", None
         )
+        self._service_pre_processing_time_in_millis: int | None = statistics.get(
+            "ServicePreProcessingTimeInMillis", None
+        )
         self._service_processing_time_in_millis: int | None = statistics.get(
             "ServiceProcessingTimeInMillis", None
         )
+        self._dpu_count: float | None = statistics.get("DpuCount")
         self._data_manifest_location: str | None = statistics.get("DataManifestLocation")
         reuse_info = statistics.get("ResultReuseInformation", {})
         self._reused_previous_result: bool | None = reuse_info.get("ReusedPreviousResult")
@@ -126,6 +130,24 @@ class AthenaQueryExecution:
         self._expected_bucket_owner: str | None = result_conf.get("ExpectedBucketOwner")
         acl_conf = result_conf.get("AclConfiguration", {})
         self._s3_acl_option: str | None = acl_conf.get("S3AclOption")
+
+        managed_results_conf = query_execution.get("ManagedQueryResultsConfiguration", {})
+        self._managed_query_results_enabled: bool | None = managed_results_conf.get("Enabled")
+        managed_results_encryption_conf = managed_results_conf.get("EncryptionConfiguration", {})
+        self._managed_query_results_kms_key: str | None = managed_results_encryption_conf.get(
+            "KmsKey"
+        )
+
+        s3_access_grants_conf = query_execution.get("QueryResultsS3AccessGrantsConfiguration", {})
+        self._enable_s3_access_grants: bool | None = s3_access_grants_conf.get(
+            "EnableS3AccessGrants"
+        )
+        self._create_user_level_prefix: bool | None = s3_access_grants_conf.get(
+            "CreateUserLevelPrefix"
+        )
+        self._s3_access_grants_authentication_type: str | None = s3_access_grants_conf.get(
+            "AuthenticationType"
+        )
 
         engine_version = query_execution.get("EngineVersion", {})
         self._selected_engine_version: str | None = engine_version.get(
@@ -225,8 +247,16 @@ class AthenaQueryExecution:
         return self._query_planning_time_in_millis
 
     @property
+    def service_pre_processing_time_in_millis(self) -> int | None:
+        return self._service_pre_processing_time_in_millis
+
+    @property
     def service_processing_time_in_millis(self) -> int | None:
         return self._service_processing_time_in_millis
+
+    @property
+    def dpu_count(self) -> float | None:
+        return self._dpu_count
 
     @property
     def output_location(self) -> str | None:
@@ -271,6 +301,26 @@ class AthenaQueryExecution:
     @property
     def result_reuse_minutes(self) -> int | None:
         return self._result_reuse_minutes
+
+    @property
+    def managed_query_results_enabled(self) -> bool | None:
+        return self._managed_query_results_enabled
+
+    @property
+    def managed_query_results_kms_key(self) -> str | None:
+        return self._managed_query_results_kms_key
+
+    @property
+    def enable_s3_access_grants(self) -> bool | None:
+        return self._enable_s3_access_grants
+
+    @property
+    def create_user_level_prefix(self) -> bool | None:
+        return self._create_user_level_prefix
+
+    @property
+    def s3_access_grants_authentication_type(self) -> str | None:
+        return self._s3_access_grants_authentication_type
 
 
 class AthenaCalculationExecutionStatus:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ authors = [
     {name = "laughingman7743", email = "laughingman7743@gmail.com"},
 ]
 dependencies = [
-    "boto3>=1.26.4",
-    "botocore>=1.29.4",
+    "boto3>=1.38.2",
+    "botocore>=1.41.2",
     "tenacity>=4.1.0",
     "fsspec",
     "python-dateutil",

--- a/tests/pyathena/test_model.py
+++ b/tests/pyathena/test_model.py
@@ -34,6 +34,17 @@ class TestAthenaQueryExecution:
                     "ResultReuseConfiguration": {
                         "ResultReuseByAgeConfiguration": {"Enabled": True, "MaxAgeInMinutes": 5}
                     },
+                    "ManagedQueryResultsConfiguration": {
+                        "Enabled": True,
+                        "EncryptionConfiguration": {
+                            "KmsKey": "test_managed_kms_key",
+                        },
+                    },
+                    "QueryResultsS3AccessGrantsConfiguration": {
+                        "EnableS3AccessGrants": True,
+                        "CreateUserLevelPrefix": True,
+                        "AuthenticationType": "DIRECTORY_IDENTITY",
+                    },
                     "QueryExecutionContext": {
                         "Database": "test_database",
                         "Catalog": "test_catalog",
@@ -57,7 +68,9 @@ class TestAthenaQueryExecution:
                         "TotalExecutionTimeInMillis": 4567890,
                         "QueryQueueTimeInMillis": 34567890,
                         "QueryPlanningTimeInMillis": 567890,
+                        "ServicePreProcessingTimeInMillis": 12345,
                         "ServiceProcessingTimeInMillis": 67890,
+                        "DpuCount": 4.0,
                         "ResultReuseInformation": {"ReusedPreviousResult": True},
                     },
                     "WorkGroup": "test_work_group",
@@ -92,7 +105,9 @@ class TestAthenaQueryExecution:
         assert actual.query_queue_time_in_millis == 34567890
         assert actual.total_execution_time_in_millis == 4567890
         assert actual.query_planning_time_in_millis == 567890
+        assert actual.service_pre_processing_time_in_millis == 12345
         assert actual.service_processing_time_in_millis == 67890
+        assert actual.dpu_count == 4.0
         assert actual.output_location == "s3://bucket/path/to/output/"
         assert actual.data_manifest_location == "s3://bucket/path/to/data_manifest/"
         assert actual.reused_previous_result
@@ -104,6 +119,29 @@ class TestAthenaQueryExecution:
         assert actual.effective_engine_version == "Athena engine version 2"
         assert actual.result_reuse_enabled
         assert actual.result_reuse_minutes == 5
+        assert actual.managed_query_results_enabled
+        assert actual.managed_query_results_kms_key == "test_managed_kms_key"
+        assert actual.enable_s3_access_grants
+        assert actual.create_user_level_prefix
+        assert actual.s3_access_grants_authentication_type == "DIRECTORY_IDENTITY"
+
+    def test_init_without_optional_fields(self):
+        actual = AthenaQueryExecution(
+            {
+                "QueryExecution": {
+                    "QueryExecutionId": "12345678-90ab-cdef-1234-567890abcdef",
+                    "Query": "SELECT 1",
+                    "Status": {"State": "SUCCEEDED"},
+                }
+            }
+        )
+        assert actual.service_pre_processing_time_in_millis is None
+        assert actual.dpu_count is None
+        assert actual.managed_query_results_enabled is None
+        assert actual.managed_query_results_kms_key is None
+        assert actual.enable_s3_access_grants is None
+        assert actual.create_user_level_prefix is None
+        assert actual.s3_access_grants_authentication_type is None
 
 
 class TestAthenaCalculationExecution:

--- a/uv.lock
+++ b/uv.lock
@@ -63,30 +63,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.35.90"
+version = "1.43.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/78/5debbc45573152267d37ff954b32743c4191b70a127f7cc52f10c7febf18/boto3-1.35.90.tar.gz", hash = "sha256:dc56caaaab2157a4bfc109c88b50cd032f3ac66c06d17f8ee335b798eaf53e5c", size = 110973, upload-time = "2024-12-28T05:34:20.493Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/4b/616367e871ce3f1cb3e8545a97736b6331b9fb081497f2d44c5b2aa6959d/boto3-1.43.14.tar.gz", hash = "sha256:5c0a994b3182061ee101812e721100717a4d664f9f4ceaf4a86b6d032ce9fc2d", size = 113142, upload-time = "2026-05-22T19:28:47.861Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/f9/1e524d35746b11240e5eb2fd9ace9fe6cf57406ad082b65012deba91d893/boto3-1.35.90-py3-none-any.whl", hash = "sha256:b0874233057995a8f0c813f5b45a36c09630e74c43d7a7c64db2feef2915d493", size = 139180, upload-time = "2024-12-28T05:34:16.869Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/00/59cb9329c18e2d3aa23062ceaa87d065f2e81e7d2931df24d64e9a7815aa/boto3-1.43.14-py3-none-any.whl", hash = "sha256:574335744656cfed0b362a0a0467aaf2eb2bf15526edcd02d31d3c661f4b09e4", size = 140536, upload-time = "2026-05-22T19:28:46.49Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.35.90"
+version = "1.43.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/39/ef713452055c942a977b92d8b0fdee3e7801cbcd08eaa2d3cb69a2aa7a44/botocore-1.35.90.tar.gz", hash = "sha256:f007f58e8e3c1ad0412a6ddfae40ed92a7bca571c068cb959902bcf107f2ae48", size = 13490924, upload-time = "2024-12-28T05:34:03.727Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/3c/798d2f7deb118241930c7c6bcfb0b970d3f0245bf580700663199aeed2c3/botocore-1.43.14.tar.gz", hash = "sha256:b9e500737e43d2f147c9d4e23b54360335e77d4c0ba90a318f51b65e06cb8516", size = 15382604, upload-time = "2026-05-22T19:28:36.363Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/10/93dae718ca769c6c6148b876b651433d80a3a372c7e159bc866fe35ccb3a/botocore-1.35.90-py3-none-any.whl", hash = "sha256:51dcbe1b32e2ac43dac17091f401a00ce5939f76afe999081802009cce1e92e4", size = 13296124, upload-time = "2024-12-28T05:33:58.761Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7e/6e64821077cd2efc4aa51b7d638fb6d48e1c7c450201c529fbaf1de8bfd3/botocore-1.43.14-py3-none-any.whl", hash = "sha256:1f4a2a95ea78c10398e78431e98c1fe47adb54a7b10a32975144c1f541186658", size = 15061424, upload-time = "2026-05-22T19:28:32.682Z" },
 ]
 
 [[package]]
@@ -1051,8 +1051,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "boto3", specifier = ">=1.26.4" },
-    { name = "botocore", specifier = ">=1.29.4" },
+    { name = "boto3", specifier = ">=1.38.2" },
+    { name = "botocore", specifier = ">=1.41.2" },
     { name = "fsspec" },
     { name = "pandas", marker = "python_full_version >= '3.13' and extra == 'pandas'", specifier = ">=2.3.0" },
     { name = "pandas", marker = "python_full_version < '3.13' and extra == 'pandas'", specifier = ">=1.3.0" },
@@ -1291,14 +1291,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.10.4"
+version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/0a/1cdbabf9edd0ea7747efdf6c9ab4e7061b085aa7f9bfc36bb1601563b069/s3transfer-0.10.4.tar.gz", hash = "sha256:29edc09801743c21eb5ecbc617a152df41d3c287f67b615f73e5f750583666a7", size = 145287, upload-time = "2024-11-20T21:06:05.981Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/ec/7c692cde9125b77e84b307354d4fb705f98b8ccad59a036d5957ca75bfc3/s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a", size = 155337, upload-time = "2026-04-29T22:07:36.33Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/05/7957af15543b8c9799209506df4660cba7afc4cf94bfb60513827e96bed6/s3transfer-0.10.4-py3-none-any.whl", hash = "sha256:244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e", size = 83175, upload-time = "2024-11-20T21:06:03.961Z" },
+    { url = "https://files.pythonhosted.org/packages/87/72/c6c32d2b657fa3dad1de340254e14390b1e334ce38268b7ad51abda3c8c2/s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20", size = 86811, upload-time = "2026-04-29T22:07:34.966Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## WHAT

Add the following fields to `AthenaQueryExecution` in `pyathena/model.py`, all introduced to the `GetQueryExecution` response since the class was last extended:

**`Statistics`:**
- `service_pre_processing_time_in_millis` — `ServicePreProcessingTimeInMillis` (botocore 1.32.3)
- `dpu_count` — `DpuCount`, per-query DPU usage exposed alongside the 2025-11 Capacity Reservations enhancements (botocore 1.41.2)

**Top-level configuration:**
- `managed_query_results_enabled` / `managed_query_results_kms_key` — `ManagedQueryResultsConfiguration` for the [Managed Query Results](https://docs.aws.amazon.com/athena/latest/ug/managed-query-results.html) feature released 2025-06 (botocore 1.38.28)
- `enable_s3_access_grants` / `create_user_level_prefix` / `s3_access_grants_authentication_type` — `QueryResultsS3AccessGrantsConfiguration` for S3 Access Grants integration

Also bumps `boto3>=1.38.2` and `botocore>=1.41.2` (Nov 2025 releases) so all new fields are actually populated by the SDK.

## WHY

These fields are returned by current boto3 versions but PyAthena was silently dropping them. Exposing them improves observability (extra timing buckets, DPU usage) and unblocks users adopting Managed Query Results and S3 Access Grants.

The lower-bound bump is conservative: without it the new properties would silently return `None` even when the user has the latest SDK and Athena returns the data. Tying the floor to the SDK release that actually serves `DpuCount` keeps the contract honest.

Closes #707