### PR TITLE
docs: note Result Reuse semantic-equivalence behavior change (2025-11)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,9 @@ name: Test
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
   schedule:
     - cron:  '0 0 * * 0'
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -156,6 +156,16 @@ pyathena.error.DatabaseError: An error occurred (InvalidRequestException) when c
 
 If for some reason you cannot use the reuse feature of Athena engine version 3, please use the {ref}`Cache configuration <cache-configuration>` implemented by PyAthena.
 
+:::{note}
+**Semantic-equivalence matching (November 2025)**
+
+As of November 2025, Athena's result reuse no longer requires byte-for-byte identical query text. Result reuse is now triggered when a query is **semantically equivalent** to a previously executed query — cosmetic differences such as whitespace, comments, or keyword casing no longer prevent a cache hit.
+
+This behavior change happens server-side; PyAthena does not need to be updated, and existing code using `result_reuse_enable` continues to work unchanged. Users who relied on exact-string matching for cache invalidation should be aware that more queries may now reuse prior results than before.
+
+See the [Athena documentation](https://docs.aws.amazon.com/athena/latest/ug/reusing-query-results.html) for the latest rules on what counts as semantically equivalent.
+:::
+
 (cache-configuration)=
 
 ### Cache configuration


### PR DESCRIPTION
## WHAT
1. Add a note in the Result reuse configuration section of `docs/usage.md` describing the November 2025 Athena server-side change: result reuse is now triggered by semantic equivalence of queries rather than exact-string match.
2. Add `paths-ignore` to `.github/workflows/test.yaml` so the full test matrix (Python 3.10-3.14 × pyathena/sqla/sqla_async, against real Athena) is skipped for docs-only PRs.

## WHY
- **Docs change**: users relying on `result_reuse_enable` may observe more cache hits than before (whitespace/comment/casing differences no longer block reuse). PyAthena code is unaffected, but the behavior change should be documented so users understand what they're seeing.
- **CI change**: tests take a long time and don't cover any code path exercised by docs-only changes. Branch protection has no required status check contexts, so skipping is safe. The weekly cron schedule continues to run tests against master.

Closes #711