### PR TITLE
docs: note JWT Trusted Identity Propagation is not supported

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -609,3 +609,16 @@ from pyathena import connect
 cursor = connect(s3_staging_dir="s3://YOUR_S3_BUCKET/path/to/",
                  region_name="us-west-2").cursor()
 ```
+
+### Unsupported: JWT Trusted Identity Propagation
+
+Amazon Athena supports [JWT-based Trusted Identity Propagation (TIP)](https://docs.aws.amazon.com/athena/latest/ug/security-iam-trusted-identity-propagation.html) for the official **JDBC and ODBC drivers**, allowing enterprise SSO identities (Okta, Entra ID, etc.) to be propagated to Athena and Lake Formation for fine-grained access control.
+
+**PyAthena does not support JWT TIP**, because this auth flow is not exposed through the AWS SDK (`boto3` / `botocore`). PyAthena builds its Athena client via boto3 and therefore relies on standard IAM-based credentials.
+
+If your environment requires JWT TIP, the options are:
+
+- Use the [Athena JDBC driver](https://docs.aws.amazon.com/athena/latest/ug/connect-with-jdbc.html) or [ODBC driver](https://docs.aws.amazon.com/athena/latest/ug/odbc-driver.html) directly.
+- Use IAM Identity Center with role-based access (assume-role flow) — see the [Assume role provider](#assume-role-provider) examples above. This is not byte-equivalent to TIP but satisfies most SSO-driven access-control requirements.
+
+This is a limitation of the AWS SDK, not of PyAthena. If `boto3`/`botocore` adds JWT TIP support in the future, PyAthena will expose it via `Connection`.


### PR DESCRIPTION
## WHAT
Add a "Unsupported: JWT Trusted Identity Propagation" subsection at the end of the Credentials section in `docs/usage.md`. Explains why JWT TIP isn't available in PyAthena and points users to either the official JDBC/ODBC drivers or IAM Identity Center assume-role as alternatives.

## WHY
AWS added JWT TIP support for the Athena JDBC/ODBC drivers (2025), but the auth flow is not exposed in `boto3`/`botocore`, so PyAthena cannot support it. Users evaluating PyAthena for SSO-driven environments need to know this upfront to avoid wasted investigation.

If `boto3`/`botocore` adds JWT TIP support later, we'll expose it via `Connection` and revisit this note.

Closes #713