### PR TITLE
ci: introduce markdownlint-cli2 and verify docs build on PRs

### DIFF
--- a/.github/workflows/docs-lint.yaml
+++ b/.github/workflows/docs-lint.yaml
@@ -1,0 +1,36 @@
+name: Docs Lint
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '**.md'
+      - '.markdownlint-cli2.jsonc'
+      - '.mise.toml'
+      - 'Makefile'
+      - '.github/workflows/docs-lint.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - run: make docs-lint
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0  # Fetch all history for sphinx-multiversion
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          enable-cache: true
+      - run: |
+          uv sync --group dev
+          make docs

--- a/.github/workflows/docs-lint.yaml
+++ b/.github/workflows/docs-lint.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-      - run: make docs-lint
+      - run: make docs/lint
 
   build:
     runs-on: ubuntu-latest
@@ -33,4 +33,4 @@ jobs:
           enable-cache: true
       - run: |
           uv sync --group dev
-          make docs
+          make docs/build

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -32,7 +32,7 @@ jobs:
           enable-cache: true
       - run: |
           uv sync --group dev
-          make docs
+          make docs/build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,40 @@
+{
+  // https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+  "config": {
+    "default": true,
+    // Line length: docs have long URLs, code blocks, and prose lines
+    "MD013": false,
+    // Match existing style: dash bullets, 2-space nested indent
+    "MD004": { "style": "dash" },
+    "MD007": { "indent": 2 },
+    // Allow inline HTML used by README (centered images) and MyST admonitions
+    "MD033": {
+      "allowed_elements": ["details", "summary", "br", "kbd", "sub", "sup", "div", "img", "p", "a"]
+    },
+    // Cursor docs intentionally repeat subsection names ("Basic usage") under different cursors
+    "MD024": { "siblings_only": true },
+    // Don't require fenced code blocks to specify a language
+    "MD040": false,
+    // Don't require blank lines around code fences / lists — existing docs intermix them
+    "MD031": false,
+    "MD032": false,
+    // Allow `$ command` style in shell snippets (testing.md, README)
+    "MD014": false,
+    // Allow bare URLs
+    "MD034": false,
+    // First line need not be a top-level heading (some files start with MyST ref targets)
+    "MD041": false
+  },
+  "globs": [
+    "docs/**/*.md",
+    "*.md"
+  ],
+  "ignores": [
+    "docs/_build/**",
+    "node_modules/**",
+    ".venv/**",
+    ".tox/**",
+    ".pytest_cache/**",
+    ".serena/**"
+  ]
+}

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -2,7 +2,7 @@
   // https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
   "config": {
     "default": true,
-    // Line length: docs have long URLs, code blocks, and prose lines
+    // Docs have long URLs and code lines that would be awkward to wrap
     "MD013": false,
     // Match existing style: dash bullets, 2-space nested indent
     "MD004": { "style": "dash" },
@@ -13,16 +13,10 @@
     },
     // Cursor docs intentionally repeat subsection names ("Basic usage") under different cursors
     "MD024": { "siblings_only": true },
-    // Don't require fenced code blocks to specify a language
-    "MD040": false,
-    // Don't require blank lines around code fences / lists — existing docs intermix them
-    "MD031": false,
-    "MD032": false,
-    // Allow `$ command` style in shell snippets (testing.md, README)
+    // `$ command` style is intentional in docs/testing.md and README shell snippets
     "MD014": false,
-    // Allow bare URLs
-    "MD034": false,
-    // First line need not be a top-level heading (some files start with MyST ref targets)
+    // MyST `(label)=` ref targets must come before the first heading, so the
+    // first line of many docs/*.md files is not an H1
     "MD041": false
   },
   "globs": [

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,2 +1,3 @@
 [tools]
 python = "3.12"
+"npm:markdownlint-cli2" = "0.18.1"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,12 +33,14 @@ make test-sqla  # SQLAlchemy dialect tests
 ```
 
 Tests require AWS environment variables. Use a `.env` file (gitignored):
+
 ```bash
 AWS_DEFAULT_REGION=<region>
 AWS_ATHENA_S3_STAGING_DIR=s3://<bucket>/<path>/
 AWS_ATHENA_WORKGROUP=<workgroup>
 AWS_ATHENA_SPARK_WORKGROUP=<spark-workgroup>
 ```
+
 ```bash
 export $(cat .env | xargs) && uv run pytest tests/pyathena/test_file.py -v
 ```
@@ -53,11 +55,13 @@ export $(cat .env | xargs) && uv run pytest tests/pyathena/test_file.py -v
 - **Standalone functions** for unit tests of pure logic (converters, parsers, utils): `def test_to_struct_json_formats(input_value, expected):`
 - Test file naming mirrors source: `pyathena/parser.py` → `tests/pyathena/test_parser.py`
 - **Fixtures**: Cursor/engine fixtures are defined in `conftest.py` and injected by name (e.g., `cursor`, `engine`, `async_cursor`). Use `indirect=True` parametrization to pass connection options:
+
   ```python
   @pytest.mark.parametrize("engine", [{"driver": "rest"}], indirect=True)
   def test_query(self, engine):
       engine, conn = engine
   ```
+
 - **Parametrize** with `@pytest.mark.parametrize(("input", "expected"), [...])` for data-driven tests
 - **Integration tests** (need AWS) use cursor/engine fixtures with real Athena queries; **unit tests** (no AWS) call functions directly with test data
 
@@ -65,10 +69,10 @@ export $(cat .env | xargs) && uv run pytest tests/pyathena/test_file.py -v
 
 `docs/**/*.md` and project-root `*.md` files are linted with [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2). The config lives at `.markdownlint-cli2.jsonc`. CI runs lint + Sphinx build on PRs that touch docs (`.github/workflows/docs-lint.yaml`).
 
-`markdownlint-cli2` is pinned in `.mise.toml` (along with `node`), so [`mise`](https://mise.jdx.dev/) installs the exact version used in CI. Run locally:
+`markdownlint-cli2` is pinned in `.mise.toml`, so [`mise`](https://mise.jdx.dev/) installs the exact version used in CI. Run locally:
 
 ```bash
-mise install          # one-time: installs node + markdownlint-cli2
+mise install          # one-time: installs markdownlint-cli2
 make docs-lint        # check
 make docs-lint-fix    # auto-fix what's possible
 ```
@@ -88,6 +92,7 @@ Each cursor type lives in its own subpackage (`pandas/`, `arrow/`, `polars/`, `s
 ### Filesystem (fsspec) Compatibility
 
 `pyathena/filesystem/s3.py` implements fsspec's `AbstractFileSystem`. When modifying:
+
 - Match `s3fs` library behavior where possible (users migrate from it)
 - Use `delimiter="/"` in S3 API calls to minimize requests
 - Handle edge cases: empty paths, trailing slashes, bucket-only paths

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,26 +1,31 @@
 # PyAthena Development Guide for AI Assistants
 
 ## Project Overview
+
 PyAthena is a Python DB API 2.0 (PEP 249) compliant client for Amazon Athena. See `pyproject.toml` for Python version support and dependencies.
 
 ## Rules and Constraints
 
 ### Git Workflow
+
 - **NEVER** commit directly to `master` — always create a feature branch and PR
 - Create PRs as drafts: `gh pr create --draft`
 
 ### Import Rules
+
 - **NEVER** use runtime imports (inside functions, methods, or conditional blocks)
 - All imports must be at the top of the file, after the license header
 - Exception: the existing codebase uses runtime imports for optional dependencies (`pyarrow`, `pandas`, etc.) in source code. For new code, use `TYPE_CHECKING` instead when possible
 
 ### Code Quality — Always Run Before Committing
+
 ```bash
 make format   # Auto-fix formatting and imports
 make lint   # Lint + format check + mypy
 ```
 
 ### Testing
+
 ```bash
 # ALWAYS run `make lint` first — tests will fail if lint doesn't pass
 make test       # Unit tests (runs chk first)
@@ -43,6 +48,7 @@ export $(cat .env | xargs) && uv run pytest tests/pyathena/test_file.py -v
 - New features require tests; changes to SQLAlchemy dialects must pass `make test-sqla`
 
 #### Test Conventions
+
 - **Class-based tests** for integration tests that use fixtures (cursors, engines): `class TestCursor:` with methods like `def test_fetchone(self, cursor):`
 - **Standalone functions** for unit tests of pure logic (converters, parsers, utils): `def test_to_struct_json_formats(input_value, expected):`
 - Test file naming mirrors source: `pyathena/parser.py` → `tests/pyathena/test_parser.py`
@@ -55,24 +61,41 @@ export $(cat .env | xargs) && uv run pytest tests/pyathena/test_file.py -v
 - **Parametrize** with `@pytest.mark.parametrize(("input", "expected"), [...])` for data-driven tests
 - **Integration tests** (need AWS) use cursor/engine fixtures with real Athena queries; **unit tests** (no AWS) call functions directly with test data
 
+### Markdown Lint
+
+`docs/**/*.md` and project-root `*.md` files are linted with [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2). The config lives at `.markdownlint-cli2.jsonc`. CI runs lint + Sphinx build on PRs that touch docs (`.github/workflows/docs-lint.yaml`).
+
+`markdownlint-cli2` is pinned in `.mise.toml` (along with `node`), so [`mise`](https://mise.jdx.dev/) installs the exact version used in CI. Run locally:
+
+```bash
+mise install          # one-time: installs node + markdownlint-cli2
+make docs-lint        # check
+make docs-lint-fix    # auto-fix what's possible
+```
+
 ## Architecture — Key Design Decisions
 
 These are non-obvious conventions that can't be discovered by reading code alone.
 
 ### PEP 249 Compliance
+
 All cursor types must implement: `execute()`, `fetchone()`, `fetchmany()`, `fetchall()`, `close()`. New cursor features must follow the DB API 2.0 specification.
 
 ### Cursor Module Pattern
+
 Each cursor type lives in its own subpackage (`pandas/`, `arrow/`, `polars/`, `s3fs/`, `spark/`) with a consistent structure: `cursor.py`, `async_cursor.py`, `converter.py`, `result_set.py`. When adding features, consider impact on all cursor types.
 
 ### Filesystem (fsspec) Compatibility
+
 `pyathena/filesystem/s3.py` implements fsspec's `AbstractFileSystem`. When modifying:
 - Match `s3fs` library behavior where possible (users migrate from it)
 - Use `delimiter="/"` in S3 API calls to minimize requests
 - Handle edge cases: empty paths, trailing slashes, bucket-only paths
 
 ### Version Management
+
 Versions are derived from git tags via `hatch-vcs` — never edit `pyathena/_version.py` manually.
 
 ### Google-style Docstrings
+
 Use Google-style docstrings for public methods. See existing code for examples.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,9 @@ make lint   # Lint + format check + mypy
 
 ```bash
 # ALWAYS run `make lint` first — tests will fail if lint doesn't pass
-make test       # Unit tests (runs chk first)
-make test-sqla  # SQLAlchemy dialect tests
+make test/pyathena    # Unit tests (runs lint first)
+make test/sqla        # SQLAlchemy dialect tests
+make test/sqla-async  # SQLAlchemy async dialect tests
 ```
 
 Tests require AWS environment variables. Use a `.env` file (gitignored):
@@ -73,8 +74,9 @@ export $(cat .env | xargs) && uv run pytest tests/pyathena/test_file.py -v
 
 ```bash
 mise install          # one-time: installs markdownlint-cli2
-make docs-lint        # check
-make docs-lint-fix    # auto-fix what's possible
+make docs/lint        # check
+make docs/format      # auto-fix what's possible
+make docs/build       # build the Sphinx site under docs/_build/html
 ```
 
 ## Architecture — Key Design Decisions

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,14 @@ docs:
 	echo 'pyathena.dev' > docs/_build/html/CNAME
 	touch docs/_build/html/.nojekyll
 
+.PHONY: docs-lint
+docs-lint:
+	mise exec -- markdownlint-cli2
+
+.PHONY: docs-lint-fix
+docs-lint-fix:
+	mise exec -- markdownlint-cli2 --fix
+
 .PHONY: tool
 tool:
 	uv tool install ruff@$(RUFF_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -13,35 +13,35 @@ lint:
 	uvx ruff@$(RUFF_VERSION) format --check .
 	uv run mypy .
 
-.PHONY: test
-test: lint
+.PHONY: test/pyathena
+test/pyathena: lint
 	uv run pytest -n 8 --cov pyathena --cov-report html --cov-report term tests/pyathena/
 
-.PHONY: test-sqla
-test-sqla:
+.PHONY: test/sqla
+test/sqla:
 	uv run pytest -n 8 --cov pyathena --cov-report html --cov-report term tests/sqlalchemy/
 
-.PHONY: test-sqla-async
-test-sqla-async:
+.PHONY: test/sqla-async
+test/sqla-async:
 	uv run pytest -n 8 --cov pyathena --cov-report html --cov-report term tests/sqlalchemy/ --dburi async
 
 .PHONY: tox
 tox:
 	uvx tox@$(TOX_VERSION) -c pyproject.toml run
 
-.PHONY: docs
-docs:
+.PHONY: docs/build
+docs/build:
 	uv run sphinx-multiversion docs docs/_build/html
 	echo '<meta http-equiv="refresh" content="0; url=./master/index.html">' > docs/_build/html/index.html
 	echo 'pyathena.dev' > docs/_build/html/CNAME
 	touch docs/_build/html/.nojekyll
 
-.PHONY: docs-lint
-docs-lint:
+.PHONY: docs/lint
+docs/lint:
 	mise exec -- markdownlint-cli2
 
-.PHONY: docs-lint-fix
-docs-lint-fix:
+.PHONY: docs/format
+docs/format:
 	mise exec -- markdownlint-cli2 --fix
 
 .PHONY: tool

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ PyAthena is a Python [DB API 2.0 (PEP 249)](https://www.python.org/dev/peps/pep-
 
 ## Requirements
 
-* Python
+- Python
 
   - CPython 3.10, 3.11, 3.12, 3.13, 3.14
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ Many of the implementations in this library are based on [PyHive](https://github
 
 ## Links
 
-- Documentation: https://pyathena.dev/
-- PyPI Releases: https://pypi.org/project/PyAthena/
-- Source Code: https://github.com/pyathena-dev/PyAthena/
-- Issue Tracker: https://github.com/pyathena-dev/PyAthena/issues
+- Documentation: <https://pyathena.dev/>
+- PyPI Releases: <https://pypi.org/project/PyAthena/>
+- Source Code: <https://github.com/pyathena-dev/PyAthena/>
+- Issue Tracker: <https://github.com/pyathena-dev/PyAthena/issues>
 
 ## Logo
 

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -293,7 +293,6 @@ cursor = connect(s3_staging_dir="s3://YOUR_S3_BUCKET/path/to/",
                  region_name="us-west-2").cursor(cursor=AsyncDictCursor, dict_type=OrderedDict)
 ```
 
-
 ## AioCursor
 
 See {ref}`aio-cursor`.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -6,7 +6,7 @@
 
 ## Requirements
 
-* Python
+- Python
 
   - CPython 3.10, 3.11, 3.12, 3.13, 3.14
 
@@ -35,23 +35,23 @@ Extra packages:
 PyAthena provides comprehensive support for Amazon Athena's data types and features:
 
 **Core Features:**
-  - **DB API 2.0 Compliance**: Full PEP 249 compatibility for database operations
-  - **SQLAlchemy Integration**: Native dialect support with table reflection and ORM capabilities
-  - **Multiple Cursor Types**: Standard, Pandas, Arrow, Polars, S3FS and Spark cursor implementations
-  - **Async Support**: Asynchronous query execution for non-blocking operations
+- **DB API 2.0 Compliance**: Full PEP 249 compatibility for database operations
+- **SQLAlchemy Integration**: Native dialect support with table reflection and ORM capabilities
+- **Multiple Cursor Types**: Standard, Pandas, Arrow, Polars, S3FS and Spark cursor implementations
+- **Async Support**: Asynchronous query execution for non-blocking operations
 
 **Data Type Support:**
-  - **STRUCT/ROW Types**: {ref}`Complete support <sqlalchemy>` for complex nested data structures
-  - **ARRAY Types**: {ref}`Complete support <sqlalchemy>` for ordered collections with automatic Python list conversion
-  - **MAP Types**: {ref}`Complete support <sqlalchemy>` for key-value dictionary-like data structures
-  - **JSON Integration**: Seamless JSON data parsing and conversion
-  - **Performance Optimized**: Smart format detection for efficient data processing
+- **STRUCT/ROW Types**: {ref}`Complete support <sqlalchemy>` for complex nested data structures
+- **ARRAY Types**: {ref}`Complete support <sqlalchemy>` for ordered collections with automatic Python list conversion
+- **MAP Types**: {ref}`Complete support <sqlalchemy>` for key-value dictionary-like data structures
+- **JSON Integration**: Seamless JSON data parsing and conversion
+- **Performance Optimized**: Smart format detection for efficient data processing
 
 **Additional Features:**
-  - **Connection Management**: Efficient connection pooling and configuration
-  - **Result Caching**: Athena query result reuse capabilities
-  - **Error Handling**: Comprehensive exception handling and recovery
-  - **S3 Integration**: Direct S3 data access and staging support
+- **Connection Management**: Efficient connection pooling and configuration
+- **Result Caching**: Athena query result reuse capabilities
+- **Error Handling**: Comprehensive exception handling and recovery
+- **S3 Integration**: Direct S3 data access and staging support
 
 (license)=
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -35,12 +35,14 @@ Extra packages:
 PyAthena provides comprehensive support for Amazon Athena's data types and features:
 
 **Core Features:**
+
 - **DB API 2.0 Compliance**: Full PEP 249 compatibility for database operations
 - **SQLAlchemy Integration**: Native dialect support with table reflection and ORM capabilities
 - **Multiple Cursor Types**: Standard, Pandas, Arrow, Polars, S3FS and Spark cursor implementations
 - **Async Support**: Asynchronous query execution for non-blocking operations
 
 **Data Type Support:**
+
 - **STRUCT/ROW Types**: {ref}`Complete support <sqlalchemy>` for complex nested data structures
 - **ARRAY Types**: {ref}`Complete support <sqlalchemy>` for ordered collections with automatic Python list conversion
 - **MAP Types**: {ref}`Complete support <sqlalchemy>` for key-value dictionary-like data structures
@@ -48,6 +50,7 @@ PyAthena provides comprehensive support for Amazon Athena's data types and featu
 - **Performance Optimized**: Smart format detection for efficient data processing
 
 **Additional Features:**
+
 - **Connection Management**: Efficient connection pooling and configuration
 - **Result Caching**: Athena query result reuse capabilities
 - **Error Handling**: Comprehensive exception handling and recovery

--- a/docs/pandas.md
+++ b/docs/pandas.md
@@ -33,7 +33,7 @@ df = as_pandas(cursor)
 print(df.describe())
 ```
 
-If you want to use the query results output to S3 directly, you can use [PandasCursor](#pandas-cursor).
+If you want to use the query results output to S3 directly, you can use {ref}`pandas-cursor`.
 This cursor fetches query results faster than the default cursor. (See [benchmark results](https://github.com/pyathena-dev/PyAthena/tree/master/benchmarks).)
 
 (to-sql)=
@@ -392,7 +392,7 @@ for df in df_iter:
     print(df.head())
 ```
 
-**Memory-efficient iteration with iter_chunks()**
+#### Memory-efficient iteration with iter_chunks()
 
 PandasCursor provides an `iter_chunks()` method for convenient chunked processing:
 
@@ -456,7 +456,7 @@ df_iter.get_chunk(10)
 df_iter.get_chunk(10)  # raise StopIteration
 ```
 
-**Auto-optimization of chunksize**
+#### Auto-optimization of chunksize
 
 PandasCursor can automatically determine optimal chunksize based on result file size when enabled:
 
@@ -506,7 +506,7 @@ AthenaPandasResultSet.AUTO_CHUNK_SIZE_LARGE = 200_000  # Larger chunks
 AthenaPandasResultSet.AUTO_CHUNK_SIZE_MEDIUM = 100_000
 ```
 
-**Performance tuning options**
+#### Performance tuning options
 
 PandasCursor accepts additional pandas.read_csv() options for performance optimization:
 
@@ -829,4 +829,3 @@ async with await aio_connect(s3_staging_dir="s3://YOUR_S3_BUCKET/path/to/",
     await cursor.execute("SELECT * FROM many_rows")
     df = cursor.as_pandas()
 ```
-

--- a/docs/polars.md
+++ b/docs/polars.md
@@ -649,4 +649,3 @@ async with await aio_connect(s3_staging_dir="s3://YOUR_S3_BUCKET/path/to/",
     await cursor.execute("SELECT * FROM many_rows")
     df = cursor.as_polars()
 ```
-

--- a/docs/sqlalchemy.md
+++ b/docs/sqlalchemy.md
@@ -130,6 +130,7 @@ location
   value: s3://bucket/path/to/
 
   Example:
+
   ```python
   Table("some_table", metadata, ..., awsathena_location="s3://bucket/path/to/")
   ```
@@ -140,6 +141,7 @@ compression
   Description: Specifies the compression format.
 
   Value:
+
 - BZIP2
 - DEFLATE
 - GZIP
@@ -151,6 +153,7 @@ compression
 - NONE|UNCOMPRESSED
 
   Example:
+
   ```python
   Table("some_table", metadata, ..., awsathena_compression="SNAPPY")
   ```
@@ -161,6 +164,7 @@ row_format
   Description: Specifies the row format of the table and its underlying source data if applicable.
 
   Value:
+
 - [DELIMITED FIELDS TERMINATED BY char [ESCAPED BY char]]
 - [DELIMITED COLLECTION ITEMS TERMINATED BY char]
 - [MAP KEYS TERMINATED BY char]
@@ -169,6 +173,7 @@ row_format
 - SERDE 'serde_name'
 
   Example:
+
   ```python
   Table("some_table", metadata, ..., awsathena_row_format="SERDE 'org.openx.data.jsonserde.JsonSerDe'")
   ```
@@ -179,6 +184,7 @@ file_format
   Description: Specifies the file format for table data.
 
   Value:
+
 - SEQUENCEFILE
 - TEXTFILE
 - RCFILE
@@ -189,6 +195,7 @@ file_format
 - INPUTFORMAT input_format_classname OUTPUTFORMAT output_format_classname
 
   Example:
+
   ```python
   Table("some_table", metadata, ..., awsathena_file_format="PARQUET")
   Table("some_table", metadata, ..., awsathena_file_format="INPUTFORMAT 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat' OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'")
@@ -200,11 +207,13 @@ serdeproperties
   Description: Specifies one or more custom properties allowed in SerDe.
 
   Value:
+
   ```python
   { "property_name": "property_value", "property_name": "property_value", ... }
   ```
 
   Example:
+
   ```python
   Table("some_table", metadata, ..., awsathena_serdeproperties={
       "separatorChar": ",", "escapeChar": "\\\\"
@@ -217,11 +226,13 @@ tblproperties
   Description: Specifies custom metadata key-value pairs for the table definition in addition to predefined table properties.
 
   Value:
+
   ```python
   { "property_name": "property_value", "property_name": "property_value", ... }
   ```
 
   Example:
+
   ```python
   Table("some_table", metadata, ..., awsathena_tblproperties={
       "projection.enabled": "true",
@@ -239,6 +250,7 @@ bucket_count
   Value: Integer value greater than or equal to 0
 
   Example:
+
   ```python
   Table("some_table", metadata, ..., awsathena_bucket_count=5)
   ```
@@ -268,6 +280,7 @@ partition
   Value: True / False
 
   Example:
+
   ```python
   Column("some_column", types.String, ..., awsathena_partition=True)
   ```
@@ -279,6 +292,7 @@ partition_transform
   Only has an effect for ICEBERG tables and when partition is set to true for the column.
 
   Value:
+
 - year
 - month
 - day
@@ -287,6 +301,7 @@ partition_transform
 - truncate
 
   Example:
+
   ```python
   Column("some_column", types.Date, ..., awsathena_partition=True, awsathena_partition_transform='year')
   ```
@@ -301,6 +316,7 @@ partition_transform_bucket_count
   Value: Integer value greater than or equal to 0
 
   Example:
+
   ```python
   Column("some_column", types.String, ..., awsathena_partition=True, awsathena_partition_transform='bucket', awsathena_partition_transform_bucket_count=5)
   ```
@@ -315,6 +331,7 @@ partition_transform_truncate_length
   Value: Integer value greater than or equal to 0
 
   Example:
+
   ```python
   Column("some_column", types.String, ..., awsathena_partition=True, awsathena_partition_transform='truncate', awsathena_partition_transform_truncate_length=5)
   ```
@@ -327,6 +344,7 @@ cluster
   Value: True / False
 
   Example:
+
   ```python
   Column("some_column", types.String, ..., awsathena_cluster=True)
   ```

--- a/docs/sqlalchemy.md
+++ b/docs/sqlalchemy.md
@@ -8,6 +8,8 @@ Supported SQLAlchemy is 1.0.0 or higher.
 For async support (`create_async_engine`), install with `pip install PyAthena[aiosqlalchemy]`
 (requires SQLAlchemy 2.0+).
 
+## Basic usage
+
 ### Sync
 
 ```python
@@ -138,15 +140,15 @@ compression
   Description: Specifies the compression format.
 
   Value:
-  * BZIP2
-  * DEFLATE
-  * GZIP
-  * LZ4
-  * LZO
-  * SNAPPY
-  * ZLIB
-  * ZSTD
-  * NONE|UNCOMPRESSED
+- BZIP2
+- DEFLATE
+- GZIP
+- LZ4
+- LZO
+- SNAPPY
+- ZLIB
+- ZSTD
+- NONE|UNCOMPRESSED
 
   Example:
   ```python
@@ -159,12 +161,12 @@ row_format
   Description: Specifies the row format of the table and its underlying source data if applicable.
 
   Value:
-  * [DELIMITED FIELDS TERMINATED BY char [ESCAPED BY char]]
-  * [DELIMITED COLLECTION ITEMS TERMINATED BY char]
-  * [MAP KEYS TERMINATED BY char]
-  * [LINES TERMINATED BY char]
-  * [NULL DEFINED AS char]
-  * SERDE 'serde_name'
+- [DELIMITED FIELDS TERMINATED BY char [ESCAPED BY char]]
+- [DELIMITED COLLECTION ITEMS TERMINATED BY char]
+- [MAP KEYS TERMINATED BY char]
+- [LINES TERMINATED BY char]
+- [NULL DEFINED AS char]
+- SERDE 'serde_name'
 
   Example:
   ```python
@@ -177,14 +179,14 @@ file_format
   Description: Specifies the file format for table data.
 
   Value:
-  * SEQUENCEFILE
-  * TEXTFILE
-  * RCFILE
-  * ORC
-  * PARQUET
-  * AVRO
-  * ION
-  * INPUTFORMAT input_format_classname OUTPUTFORMAT output_format_classname
+- SEQUENCEFILE
+- TEXTFILE
+- RCFILE
+- ORC
+- PARQUET
+- AVRO
+- ION
+- INPUTFORMAT input_format_classname OUTPUTFORMAT output_format_classname
 
   Example:
   ```python
@@ -277,12 +279,12 @@ partition_transform
   Only has an effect for ICEBERG tables and when partition is set to true for the column.
 
   Value:
-  * year
-  * month
-  * day
-  * hour
-  * bucket
-  * truncate
+- year
+- month
+- day
+- hour
+- bucket
+- truncate
 
   Example:
   ```python
@@ -564,11 +566,11 @@ with engine.connect() as connection:
 
 The `on_start_query_execution` callback is supported by all PyAthena SQLAlchemy dialects:
 
-* `awsathena` and `awsathena+rest` (default cursor)
-* `awsathena+pandas` (pandas cursor)
-* `awsathena+arrow` (arrow cursor)
-* `awsathena+polars` (polars cursor)
-* `awsathena+s3fs` (S3FS cursor)
+- `awsathena` and `awsathena+rest` (default cursor)
+- `awsathena+pandas` (pandas cursor)
+- `awsathena+arrow` (arrow cursor)
+- `awsathena+polars` (polars cursor)
+- `awsathena+s3fs` (S3FS cursor)
 
 Usage with different dialects:
 
@@ -1089,10 +1091,10 @@ print(type(result.json_col))  # <class 'dict'>
 
 Athena's JSON type support has specific limitations:
 
-* **JSON objects are fully supported** - Objects with key-value pairs work correctly
-* **Top-level JSON arrays are not supported** - Direct CAST of arrays like `[1, 2, 3]` will fail
-* **Arrays within objects are supported** - JSON objects can contain arrays as property values
-* **DML only** - JSON type is supported for SELECT queries but not in CREATE TABLE statements
+- **JSON objects are fully supported** - Objects with key-value pairs work correctly
+- **Top-level JSON arrays are not supported** - Direct CAST of arrays like `[1, 2, 3]` will fail
+- **Arrays within objects are supported** - JSON objects can contain arrays as property values
+- **DML only** - JSON type is supported for SELECT queries but not in CREATE TABLE statements
 
 ```python
 # Supported: JSON object with nested array

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -33,8 +33,9 @@ $ export AWS_ATHENA_MANAGED_WORKGROUP=pyathena-managed
 
 ```bash
 $ pip install uv or pipx install uv or brew install uv or mise install uv
-$ make test
-$ make test-sqla
+$ make test/pyathena
+$ make test/sqla
+$ make test/sqla-async
 ```
 
 ## Run test multiple Python versions

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -379,12 +379,12 @@ cursor.execute(
 
 The `on_start_query_execution` callback is supported by the following cursor types:
 
-* `Cursor` (default cursor)
-* `DictCursor`
-* `ArrowCursor`
-* `PandasCursor`
-* `PolarsCursor`
-* `S3FSCursor`
+- `Cursor` (default cursor)
+- `DictCursor`
+- `ArrowCursor`
+- `PandasCursor`
+- `PolarsCursor`
+- `S3FSCursor`
 
 Note: `AsyncCursor` and its variants do not support this callback as they already
 return the query ID immediately through their different execution model.
@@ -475,11 +475,11 @@ column. You can mix both styles in the same dictionary.
 
 ### Constraints
 
-* **Nested arrays in native format** — Athena's native (non-JSON) string representation
+- **Nested arrays in native format** — Athena's native (non-JSON) string representation
   does not clearly delimit nested arrays. If your query returns nested arrays
   (e.g. `array(array(integer))`), use `CAST(... AS JSON)` in your query to get
   JSON-formatted output, which is parsed reliably.
-* **Arrow, Pandas, and Polars cursors** — These cursors accept `result_set_type_hints`
+- **Arrow, Pandas, and Polars cursors** — These cursors accept `result_set_type_hints`
   but their converters do not currently use the hints because they rely on their own
   type systems. The parameter is passed through for forward compatibility and for
   result sets that fall back to the default conversion path.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,9 +226,9 @@ allowlist_externals =
     make
 commands =
     uv sync --group dev
-    pyathena: make test
-    sqla: make test-sqla
-    sqla_async: make test-sqla-async
+    pyathena: make test/pyathena
+    sqla: make test/sqla
+    sqla_async: make test/sqla-async
 passenv =
     TOXENV
     AWS_*


### PR DESCRIPTION
## WHAT

Closes #717.

- Add `.markdownlint-cli2.jsonc` tuned to PyAthena's existing Markdown style (dash bullets, 2-space nested indent, allow inline HTML used by README centered-image markup and MyST admonitions).
- Pin `markdownlint-cli2@0.18.1` via `.mise.toml` using mise's `npm:` backend. No `node` declaration needed — mise resolves it automatically.
- Add `.github/workflows/docs-lint.yaml` that runs on PRs touching `docs/**`, `**.md`, `.markdownlint-cli2.jsonc`, `.mise.toml`, `Makefile`, or the workflow itself. Two jobs:
  - **lint** — `make docs/lint` (markdownlint-cli2)
  - **build** — `make docs/build` (sphinx-multiversion)
- Namespace make targets with `/`:
  - `docs` → `docs/build`; added `docs/lint`, `docs/format`
  - `test` → `test/pyathena`; `test-sqla` → `test/sqla`; `test-sqla-async` → `test/sqla-async`
  - Tox config (`pyproject.toml`) and existing CI workflows updated to match.
- Fix all existing Markdown lint violations (auto-fix + 5 manual: `MD051` MyST `{ref}`, three `MD036` heading promotions in pandas.md, `MD001` "Basic usage" wrapper in sqlalchemy.md, 4 bare README footer URLs wrapped in `<...>`).
- Enable rules that auto-fix or have small violation counts: `MD031`, `MD032`, `MD034`, `MD040`.
- Document the local workflow in `CLAUDE.md`.

Intentionally **kept disabled** with rationale in `.markdownlint-cli2.jsonc`:

- `MD013` (line length) — docs have long URLs and code lines
- `MD014` (`$` without output) — intentional in `docs/testing.md` and README shell snippets
- `MD024` `siblings_only: true` — cursor docs reuse subsection names
- `MD041` (first line H1) — MyST `(label)=` ref targets precede the first heading

## WHY

The docs Sphinx build currently runs only on `push` to `master` (`.github/workflows/docs.yaml`). Syntax errors, broken cross-references, or other build failures are only caught after merge. Markdown style also drifts across files (`*`/`-` bullets mixed, missing blanks around fences, etc.).

This PR catches both classes of failure on the PR itself, and aligns existing files with one consistent style without changing rendered output.