### PR TITLE
Fix empty object write for small files in fsspec transactions

### DIFF
--- a/pyathena/filesystem/s3.py
+++ b/pyathena/filesystem/s3.py
@@ -1409,11 +1409,18 @@ class S3File(AbstractBufferedFile):
                 )
 
     def _upload_chunk(self, final: bool = False) -> bool:
+        # The return value controls whether fsspec's flush() resets self.buffer
+        # afterwards: it does so only when this returns a value other than False.
+        # Returning ``not final`` keeps the buffer intact on the final flush so a
+        # deferred commit() (autocommit=False, i.e. inside an fsspec transaction)
+        # can still read the bytes; resetting it there would upload an empty
+        # object for small files. Mid-stream chunks (final=False) return True so
+        # fsspec clears the already-uploaded buffer between parts.
         if self.tell() < self.blocksize:
             # Files smaller than block size in size cannot be multipart uploaded.
             if self.autocommit and final:
                 self.commit()
-            return True
+            return not final
 
         if not self.multipart_upload:
             raise RuntimeError("Multipart upload is not initialized.")
@@ -1456,7 +1463,7 @@ class S3File(AbstractBufferedFile):
 
         if self.autocommit and final:
             self.commit()
-        return True
+        return not final
 
     def commit(self) -> None:
         if self.tell() == 0:

--- a/tests/pyathena/filesystem/test_s3.py
+++ b/tests/pyathena/filesystem/test_s3.py
@@ -1,12 +1,16 @@
+import io
 import os
 import tempfile
 import time
 import urllib.parse
 import urllib.request
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from itertools import chain
 from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
 
 import fsspec
 import pytest
@@ -193,6 +197,56 @@ class TestS3FileSystem:
             actual = f.read()
             assert len(actual) == len(data)
             assert actual == data
+
+    @pytest.mark.parametrize(
+        "size",
+        [
+            2**10,  # < block size: one-shot PutObject path (the GH-719 regression)
+            10 * 2**20,  # > block size (5 MiB): multipart CompleteMultipartUpload path
+        ],
+    )
+    def test_write_transaction(self, fs, size):
+        # Regression test for GH-719: files written inside an fsspec transaction
+        # (autocommit=False) must round-trip with their real content (small files
+        # were previously committed as empty objects).
+        data = b"a" * size
+        path = (
+            f"s3://{ENV.s3_staging_bucket}/{ENV.s3_staging_key}{ENV.schema}/"
+            f"filesystem/test_write_transaction/{uuid.uuid4()}"
+        )
+        with fs.transaction, fs.open(path, "wb") as f:
+            f.write(data)
+        with fs.open(path, "rb") as f:
+            actual = f.read()
+            assert len(actual) == len(data)
+            assert actual == data
+
+    @pytest.mark.parametrize(
+        "size",
+        [
+            2**10,  # < block size: small-file discard() is a no-op
+            10 * 2**20,  # > block size: discard() aborts the multipart upload
+        ],
+    )
+    def test_write_transaction_rollback(self, fs, size):
+        # Raising inside the transaction must leave no object behind.
+        data = b"a" * size
+        path = (
+            f"s3://{ENV.s3_staging_bucket}/{ENV.s3_staging_key}{ENV.schema}/"
+            f"filesystem/test_write_transaction_rollback/{uuid.uuid4()}"
+        )
+
+        def write_then_fail():
+            with fs.transaction:
+                f = fs.open(path, "wb")
+                f.write(data)
+                f.close()
+                raise RuntimeError("rollback")
+
+        with pytest.raises(RuntimeError):
+            write_then_fail()
+        fs.invalidate_cache(path)
+        assert not fs.exists(path)
 
     @pytest.mark.parametrize(
         ("base", "exp"),
@@ -820,6 +874,40 @@ class TestS3FileSystem:
 
 
 class TestS3File:
+    @staticmethod
+    def _make_write_file(data: bytes, autocommit: bool):
+        # Build a minimal write-mode S3File without touching AWS, bypassing
+        # __init__ which would require a real connection.
+        file = S3File.__new__(S3File)
+        file.fs = mock.MagicMock(spec=S3FileSystem)
+        file.path = "s3://bucket/key.txt"
+        file.bucket = "bucket"
+        file.key = "key.txt"
+        file.s3_additional_kwargs = {}
+        file.autocommit = autocommit
+        file.blocksize = S3FileSystem.MULTIPART_UPLOAD_MIN_PART_SIZE
+        file.multipart_upload = None
+        file.multipart_upload_parts = []
+        file.buffer = io.BytesIO(data)
+        file.loc = len(data)  # tell() returns self.loc
+        return file
+
+    @staticmethod
+    def _make_multipart_write_file(data: bytes, autocommit: bool):
+        # A write-mode S3File set up to take the multipart branch (blocksize <
+        # len(data)), with the executor and S3 part calls mocked so no AWS
+        # access is needed.
+        file = TestS3File._make_write_file(data, autocommit=autocommit)
+        file.blocksize = 4
+        file.fs.MULTIPART_UPLOAD_MIN_PART_SIZE = 4
+        file.fs.MULTIPART_UPLOAD_MAX_PART_SIZE = 8
+        file.multipart_upload = SimpleNamespace(upload_id="uploadid")
+        file._executor = ThreadPoolExecutor(max_workers=1)
+        file.fs._upload_part.side_effect = lambda **kw: SimpleNamespace(
+            etag=f'"e{kw["part_number"]}"', part_number=kw["part_number"]
+        )
+        return file
+
     @pytest.mark.parametrize(
         ("objects", "target"),
         [
@@ -867,3 +955,75 @@ class TestS3File:
 
     def test_format_ranges(self):
         assert S3File._format_ranges((0, 100)) == "bytes=0-99"
+
+    @pytest.mark.parametrize("autocommit", [True, False])
+    def test_upload_chunk_small_file(self, autocommit):
+        # Single (one-shot PutObject) upload via _upload_chunk + commit.
+        # autocommit=True  -> normal open(), committed immediately.
+        # autocommit=False -> inside a transaction, commit() is deferred to
+        #                     Transaction.complete(). This is the GH-719 case:
+        #                     _upload_chunk must return False so fsspec.flush()
+        #                     keeps self.buffer for the deferred commit, instead
+        #                     of resetting it and uploading an empty object.
+        data = b"hello world"
+        file = self._make_write_file(data, autocommit=autocommit)
+
+        assert file._upload_chunk(final=True) is False
+        if not autocommit:
+            # Deferred: nothing is uploaded until commit() runs.
+            file.fs._put_object.assert_not_called()
+            file.commit()
+        file.fs._put_object.assert_called_once_with(bucket="bucket", key="key.txt", body=data)
+
+    def test_upload_chunk_empty_file_touches(self):
+        # An intentionally empty file (tell() == 0) is created via touch(),
+        # never via _put_object.
+        file = self._make_write_file(b"", autocommit=True)
+
+        assert file._upload_chunk(final=True) is False
+        file.fs.touch.assert_called_once()
+        file.fs._put_object.assert_not_called()
+
+    @pytest.mark.parametrize("multipart", [False, True])
+    def test_discard(self, multipart):
+        # Rollback (Transaction.complete(commit=False)) never creates the object:
+        # a single small file is a no-op, while a multipart upload is aborted.
+        if multipart:
+            file = self._make_multipart_write_file(b"x" * 16, autocommit=False)
+        else:
+            file = self._make_write_file(b"hello world", autocommit=False)
+        assert file._upload_chunk(final=True) is False
+
+        file.discard()
+
+        if multipart:
+            file.fs._call.assert_called_once()
+            assert file.fs._call.call_args.args[0] == "abort_multipart_upload"
+        else:
+            file.fs._call.assert_not_called()
+        file.fs._put_object.assert_not_called()
+        assert file.multipart_upload is None
+        assert file.multipart_upload_parts == []
+
+    @pytest.mark.parametrize("autocommit", [True, False])
+    def test_upload_chunk_multipart(self, autocommit):
+        # Multipart upload (CompleteMultipartUpload), completed from the uploaded
+        # parts; the buffer is never read for the body and no one-shot PutObject
+        # is issued. autocommit=True completes inside _upload_chunk; autocommit=
+        # False (transaction) defers completion to commit().
+        #
+        # The mid-stream assertion also guards why _upload_chunk returns
+        # `not final` rather than a plain False (as s3fs does): PyAthena delegates
+        # mid-stream buffer management to fsspec, so a non-final chunk MUST return
+        # True to have fsspec reset the buffer between parts. Returning False
+        # mid-stream would re-upload the already-sent buffer.
+        file = self._make_multipart_write_file(b"x" * 16, autocommit=autocommit)
+
+        assert file._upload_chunk(final=False) is True  # mid-stream -> buffer reset
+        assert file._upload_chunk(final=True) is False  # final -> buffer kept
+        if not autocommit:
+            # Deferred: the multipart upload is completed by commit().
+            file.fs._complete_multipart_upload.assert_not_called()
+            file.commit()
+        file.fs._complete_multipart_upload.assert_called_once()
+        file.fs._put_object.assert_not_called()

--- a/tests/pyathena/filesystem/test_s3_async.py
+++ b/tests/pyathena/filesystem/test_s3_async.py
@@ -189,6 +189,50 @@ class TestAioS3FileSystem:
             assert actual == data
 
     @pytest.mark.parametrize(
+        "size",
+        [
+            2**10,  # < block size: one-shot PutObject path (the GH-719 regression)
+            10 * 2**20,  # > block size (5 MiB): multipart path via the async executor
+        ],
+    )
+    def test_write_transaction(self, fs, size):
+        # GH-719 regression for the async filesystem: AioS3File inherits
+        # _upload_chunk/commit from S3File, so the transaction fix must hold here
+        # too, including the multipart path driven by the async executor.
+        data = b"a" * size
+        path = (
+            f"s3://{ENV.s3_staging_bucket}/{ENV.s3_staging_key}{ENV.schema}/"
+            f"filesystem/test_async_write_transaction/{uuid.uuid4()}"
+        )
+        with fs.transaction, fs.open(path, "wb") as f:
+            f.write(data)
+        with fs.open(path, "rb") as f:
+            actual = f.read()
+            assert len(actual) == len(data)
+            assert actual == data
+
+    def test_write_transaction_rollback(self, fs):
+        # Kept small-only on purpose: the multipart discard()/abort path is
+        # already exercised by the sync test (AioS3File inherits discard()),
+        # so there is no need to pay for another large upload here.
+        path = (
+            f"s3://{ENV.s3_staging_bucket}/{ENV.s3_staging_key}{ENV.schema}/"
+            f"filesystem/test_async_write_transaction_rollback/{uuid.uuid4()}"
+        )
+
+        def write_then_fail():
+            with fs.transaction:
+                f = fs.open(path, "wb")
+                f.write(b"hello world")
+                f.close()
+                raise RuntimeError("rollback")
+
+        with pytest.raises(RuntimeError):
+            write_then_fail()
+        fs.invalidate_cache(path)
+        assert not fs.exists(path)
+
+    @pytest.mark.parametrize(
         ("base", "exp"),
         [
             (1, 2**10),


### PR DESCRIPTION
## WHAT

Fixes #719 — small files (smaller than the block size, default 5 MiB) written inside an fsspec [transaction](https://filesystem-spec.readthedocs.io/en/latest/features.html#transactions) (`autocommit=False`) were committed to S3 as **empty objects**.

The fix in `pyathena/filesystem/s3.py` is a one-liner (twice): `S3File._upload_chunk` now returns `not final` instead of `True`. `commit()` and `__init__` are unchanged.

## WHY

`S3File.close()` triggers fsspec's `flush(force=True)`, and fsspec resets `self.buffer` after the upload **only when `_upload_chunk` returns a value other than `False`**:

```python
# fsspec/spec.py
if self._upload_chunk(final=force) is not False:
    self.offset += self.buffer.seek(0, 2)
    self.buffer = io.BytesIO()   # buffer reset
```

`_upload_chunk` previously returned `True` unconditionally. For a small file the actual upload is deferred to `commit()`:

- **autocommit** (normal `open()`): `commit()` runs synchronously inside `_upload_chunk`, before the reset — works.
- **transaction** (`autocommit=False`): `commit()` is deferred to `Transaction.complete()`, which runs *after* fsspec reset the buffer, so it reads an empty buffer and sends `body=b""` to `PutObject`.

Returning `not final` fixes this:

- Mid-stream chunks (`final=False`) → `True`: fsspec clears the already-uploaded buffer between multipart parts (PyAthena delegates mid-stream buffer management to fsspec).
- Final flush (`final=True`) → `False`: fsspec leaves the buffer intact, so the deferred `commit()` reads the real bytes.

This mirrors how **s3fs** solves the same problem — s3fs returns `False` from `_upload_chunk` to keep the buffer, and `commit()` reads from it. (s3fs returns `False` unconditionally because it does its own mid-stream buffer bookkeeping; PyAthena uses `not final` because it relies on fsspec for that.) The large-file/multipart path's `commit()` completes the upload from the already-uploaded parts and never reads the buffer.

`AioS3File` inherits `_upload_chunk`/`commit` from `S3File`, so the async filesystem benefits from the same fix.

This keeps PyAthena's custom `S3FileSystem` (which intentionally avoids the `s3fs`/`aiobotocore` dependency) and supports fsspec transactions properly rather than handing filesystem ownership back to `s3fs`.

## Tests

### Unit (no AWS) — `tests/pyathena/filesystem/test_s3.py::TestS3File`

Drive `S3File._upload_chunk`/`commit`/`discard` with a mocked filesystem (no AWS), asserting the fsspec return-value contract. Parametrized to cover the full matrix of `autocommit` (transaction vs not) × single vs multipart × commit vs rollback:

| Test | autocommit / transaction | upload | path |
| --- | --- | --- | --- |
| `test_upload_chunk_small_file[True]` | autocommit (no txn) | single | one-shot `PutObject`, committed in-line |
| `test_upload_chunk_small_file[False]` | transaction | single | **GH-719 regression** — deferred commit reads the preserved buffer |
| `test_upload_chunk_multipart[True]` | autocommit (no txn) | multipart | `CompleteMultipartUpload` in-line |
| `test_upload_chunk_multipart[False]` | transaction | multipart | `CompleteMultipartUpload` deferred to commit |
| `test_discard[False]` | transaction (rollback) | single | no-op (object never created) |
| `test_discard[True]` | transaction (rollback) | multipart | `AbortMultipartUpload` |
| `test_upload_chunk_empty_file_touches` | autocommit | empty | `touch` (never `PutObject`) |

The multipart tests also assert the mid-stream invariant (non-final → `True` so fsspec resets the buffer between parts; final → `False`), which guards against a future "simplification" to a plain `return False` that would corrupt multipart uploads.

### Integration (real AWS) — sync (`test_s3.py`) and async (`test_s3_async.py`)

`test_write_transaction` / `test_write_transaction_rollback`, parametrized over a small (one-shot `PutObject`) and a 10 MiB (multipart) size:

- write inside `with fs.transaction:` round-trips with the real content;
- raising inside the transaction leaves no object (`CompleteMultipartUpload` vs `AbortMultipartUpload` paths exercised end-to-end, incl. the async executor).

**AWS cost.** The large (10 MiB) cases are bounded to **three uploads total** (sync write, sync rollback, async write; the async rollback stays small since `AioS3File` inherits `discard()`). These live at the **filesystem layer**, so they run once each and are **not multiplied across cursor types** (pandas/arrow/polars). No multi-GiB cases are added.

## Verification

- `make lint` — passes (ruff + format check + mypy).
- 21 unit + 7 integration transaction cases pass against real AWS.
- Confirmed the `[False]` unit cases fail when the source fix is reverted (regression guard), and the multipart mid-stream assertion fails under a plain `return False` (anti-simplification guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)