### PR TITLE
Bump boto3 lower bound to >=1.41.2 to match botocore floor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
     {name = "laughingman7743", email = "laughingman7743@gmail.com"},
 ]
 dependencies = [
-    "boto3>=1.38.2",
+    "boto3>=1.41.2",
     "botocore>=1.41.2",
     "tenacity>=4.1.0",
     "fsspec",

--- a/uv.lock
+++ b/uv.lock
@@ -998,7 +998,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "boto3", specifier = ">=1.38.2" },
+    { name = "boto3", specifier = ">=1.41.2" },
     { name = "botocore", specifier = ">=1.41.2" },
     { name = "fsspec" },
     { name = "pandas", marker = "python_full_version >= '3.13' and extra == 'pandas'", specifier = ">=2.3.0" },


### PR DESCRIPTION
## WHAT

Bump the `boto3` lower bound from `>=1.38.2` to `>=1.41.2` to match the existing `botocore>=1.41.2` floor.

```diff
-    "boto3>=1.38.2",
+    "boto3>=1.41.2",
     "botocore>=1.41.2",
```

`uv.lock` is regenerated; only the specifier metadata changes (resolved versions were already `boto3`/`botocore` 1.43.14).

## WHY

`boto3 1.38.2` declares `botocore<1.39.0,>=1.38.2`, which has an **empty intersection** with the current `botocore>=1.41.2` floor (raised in #708 for `DpuCount`). As a result, `boto3>=1.38.2` was never actually satisfiable together with the `botocore` floor — pip already resolves `boto3` up to `>=1.41.2` in practice, so the declared `1.38.2` floor was misleading.

botocore/boto3 ship in lockstep (matching version numbers), so the `boto3` floor should track the `botocore` floor. `boto3 1.41.2` requires `botocore<1.42.0,>=1.41.2`, which aligns with the existing constraint.

This is a follow-up to #708 / #709 (Managed Query Results): the managed-query-result workgroup APIs landed in botocore 1.38.28 and are already covered by the 1.41.2 floor, so no further bump is needed beyond making the `boto3` floor consistent.