### PR TITLE
Add filesystem API parity features to the built-in S3FileSystem

### DIFF
--- a/pyathena/filesystem/s3.py
+++ b/pyathena/filesystem/s3.py
@@ -1380,8 +1380,13 @@ class S3FileSystem(AbstractFileSystem):
         if key and acl not in self.OBJECT_ACLS:
             raise ValueError(f"ACL not in {self.OBJECT_ACLS}.")
         if recursive:
-            for p in self.find(path, withdirs=False):
-                self.chmod(p, acl, recursive=False, **kwargs)
+            with self._create_executor(max_workers=self.max_workers) as executor:
+                futures = [
+                    executor.submit(self.chmod, p, acl, recursive=False, **kwargs)
+                    for p in self.find(path, withdirs=False)
+                ]
+                for future in as_completed(futures):
+                    future.result()
         elif key:
             request: dict[str, Any] = {"Bucket": bucket, "Key": key, "ACL": acl}
             if version_id:

--- a/pyathena/filesystem/s3.py
+++ b/pyathena/filesystem/s3.py
@@ -22,6 +22,7 @@ from fsspec.spec import AbstractBufferedFile
 from fsspec.utils import tokenize
 
 import pyathena
+from pyathena.filesystem.s3_errors import translate_client_error
 from pyathena.filesystem.s3_executor import S3Executor, S3ThreadPoolExecutor
 from pyathena.filesystem.s3_object import (
     S3CompleteMultipartUpload,
@@ -93,6 +94,21 @@ class S3FileSystem(AbstractFileSystem):
     # https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html
     DELETE_OBJECTS_MAX_KEYS: int = 1000
     DEFAULT_BLOCK_SIZE: int = 5 * 2**20  # 5MiB
+    # https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl
+    OBJECT_ACLS: frozenset[str] = frozenset(
+        {
+            "private",
+            "public-read",
+            "public-read-write",
+            "authenticated-read",
+            "aws-exec-read",
+            "bucket-owner-read",
+            "bucket-owner-full-control",
+        }
+    )
+    BUCKET_ACLS: frozenset[str] = frozenset(
+        {"private", "public-read", "public-read-write", "authenticated-read"}
+    )
     PATTERN_PATH: Pattern[str] = re.compile(
         r"(^s3://|^s3a://|^)(?P<bucket>[a-zA-Z0-9.\-_]+)(/(?P<key>[^?]+)|/)?"
         r"($|\?version(Id|ID|id|_id)=(?P<version_id>.+)$)"
@@ -200,10 +216,8 @@ class S3FileSystem(AbstractFileSystem):
                     self._client.head_bucket,
                     Bucket=bucket,
                 )
-            except botocore.exceptions.ClientError as e:
-                if e.response["Error"]["Code"] in ["NoSuchKey", "NoSuchBucket", "404"]:
-                    return None
-                raise
+            except FileNotFoundError:
+                return None
             file = S3Object(
                 init={
                     "ContentLength": 0,
@@ -239,10 +253,8 @@ class S3FileSystem(AbstractFileSystem):
                     self._client.head_object,
                     **request,
                 )
-            except botocore.exceptions.ClientError as e:
-                if e.response["Error"]["Code"] in ["NoSuchKey", "NoSuchBucket", "404"]:
-                    return None
-                raise
+            except FileNotFoundError:
+                return None
             file = S3Object(
                 init=response,
                 type=S3ObjectType.S3_OBJECT_TYPE_FILE,
@@ -399,7 +411,7 @@ class S3FileSystem(AbstractFileSystem):
                 version_id=None,
             )
         if not refresh:
-            caches: list[S3Object] | S3Object = self._ls_from_cache(path)
+            caches: list[S3Object] | S3Object | None = self._ls_from_cache(path)
             if caches is not None:
                 if isinstance(caches, list):
                     cache = next((c for c in caches if c.name == path), None)
@@ -735,6 +747,112 @@ class S3FileSystem(AbstractFileSystem):
                 )
             for f in as_completed(fs):
                 f.result()
+
+    def mkdir(self, path: str, create_parents: bool = True, **kwargs) -> None:
+        """Create an S3 bucket.
+
+        S3 has no real directories below the bucket level; creating a key
+        prefix requires no operation. This method creates the bucket when the
+        path points at a bucket (or when ``create_parents`` is True and the
+        bucket does not exist yet), and does nothing for key prefixes under
+        an existing bucket.
+
+        Args:
+            path: S3 path (e.g., "s3://bucket" or "s3://bucket/prefix").
+            create_parents: If True, create the bucket when it does not exist,
+                even if the path contains a key prefix.
+            **kwargs: Additional arguments including:
+                acl: Canned ACL to apply to the bucket.
+                region_name: Region to create the bucket in. Defaults to the
+                    client's region.
+
+        Raises:
+            FileExistsError: If the path is a bucket that already exists.
+            FileNotFoundError: If the bucket does not exist and
+                ``create_parents`` is False.
+            ValueError: If the ACL is invalid or the path is empty.
+        """
+        path = self._strip_protocol(path).rstrip("/")
+        if not path:
+            raise ValueError("Cannot create the root directory.")
+        bucket, key, _ = self.parse_path(path)
+        if self.exists(bucket):
+            if not key:
+                # Requested to create a bucket, but the bucket already exists.
+                raise FileExistsError(bucket)
+            # Do nothing as the bucket already exists.
+        elif not key or create_parents:
+            acl = kwargs.pop("acl", "")
+            if acl and acl not in self.BUCKET_ACLS:
+                raise ValueError(f"ACL not in {self.BUCKET_ACLS}.")
+            request: dict[str, Any] = {"Bucket": bucket}
+            if acl:
+                request.update({"ACL": acl})
+            region_name = kwargs.pop("region_name", None) or self._client.meta.region_name
+            if region_name and region_name != "us-east-1":
+                # us-east-1 does not accept a location constraint.
+                request.update({"CreateBucketConfiguration": {"LocationConstraint": region_name}})
+
+            _logger.debug("Create bucket: s3://%s", bucket)
+            try:
+                self._call(
+                    self._client.create_bucket,
+                    **request,
+                )
+            except botocore.exceptions.ParamValidationError as e:
+                raise ValueError(f"Bucket create failed {bucket!r}: {e}") from e
+            self.invalidate_cache("")
+            self.invalidate_cache(bucket)
+        else:
+            # Raises FileNotFoundError if the bucket does not exist
+            # and it is not requested to be created.
+            self.ls(bucket)
+
+    def makedirs(self, path: str, exist_ok: bool = False) -> None:
+        """Recursively create a directory, creating the bucket if necessary.
+
+        Args:
+            path: S3 path (e.g., "s3://bucket" or "s3://bucket/prefix").
+            exist_ok: If False, raise FileExistsError when the bucket
+                already exists.
+        """
+        try:
+            self.mkdir(path, create_parents=True)
+        except FileExistsError:
+            if not exist_ok:
+                raise
+
+    def rmdir(self, path: str) -> None:
+        """Remove an S3 bucket, which must be empty.
+
+        S3 has no real directories below the bucket level, so only bucket
+        paths can be removed.
+
+        Args:
+            path: S3 bucket path (e.g., "s3://bucket").
+
+        Raises:
+            FileExistsError: If the path contains a key that exists. The user
+                may have meant ``rm(path, recursive=True)``.
+            FileNotFoundError: If the path contains a key that does not exist,
+                or the bucket does not exist.
+            OSError: If the bucket is not empty.
+        """
+        path = self._strip_protocol(path).rstrip("/")
+        bucket, key, _ = self.parse_path(path)
+        if key:
+            if self.exists(path):
+                # The user may have meant rm(path, recursive=True).
+                raise FileExistsError(path)
+            raise FileNotFoundError(path)
+
+        _logger.debug("Delete bucket: s3://%s", bucket)
+        self._call(
+            self._client.delete_bucket,
+            Bucket=bucket,
+        )
+        self.invalidate_cache(bucket)
+        self.invalidate_cache("")
 
     def touch(self, path: str, truncate: bool = True, **kwargs) -> dict[str, Any]:
         bucket, key, version_id = self.parse_path(path)
@@ -1084,6 +1202,257 @@ class S3FileSystem(AbstractFileSystem):
             **request,
         )
 
+    def metadata(self, path: str, **kwargs) -> dict[str, Any]:
+        """Return the user-defined metadata (``x-amz-meta-*``) of the path.
+
+        Args:
+            path: S3 path (s3://bucket/key) to get metadata for.
+            **kwargs: Additional parameters passed to the HeadObject API.
+
+        Returns:
+            Dictionary of the user-defined metadata with the keys' underscores
+            replaced by hyphens.
+        """
+        bucket, key, version_id = self.parse_path(path)
+        if not key:
+            raise ValueError("Cannot get metadata of a bucket.")
+        request: dict[str, Any] = {"Bucket": bucket, "Key": key}
+        if version_id:
+            request.update({"VersionId": version_id})
+
+        _logger.debug("Head object metadata: s3://%s/%s?versionId=%s", bucket, key, version_id)
+        response = self._call(
+            self._client.head_object,
+            **request,
+            **kwargs,
+        )
+        return {k.replace("_", "-"): v for k, v in response["Metadata"].items()}
+
+    def getxattr(self, path: str, attr_name: str, **kwargs) -> Any:
+        """Get an attribute from the user-defined metadata of the path.
+
+        Args:
+            path: S3 path (s3://bucket/key) to get the attribute for.
+            attr_name: The name of the attribute. Underscores are replaced
+                by hyphens to match the metadata key format.
+            **kwargs: Additional parameters passed to :meth:`metadata`.
+
+        Returns:
+            The value of the attribute, or None if the attribute is not set.
+        """
+        attr_name = attr_name.replace("_", "-")
+        xattr = self.metadata(path, **kwargs)
+        if attr_name in xattr:
+            return xattr[attr_name]
+        return None
+
+    def setxattr(self, path: str, copy_kwargs: dict[str, Any] | None = None, **kw_args) -> None:
+        """Set the user-defined metadata of the path.
+
+        S3 does not allow updating the metadata of an existing object in
+        place, so the object is copied onto itself with the REPLACE metadata
+        directive. Note that this rewrites the object and updates its
+        last-modified time.
+
+        Args:
+            path: S3 path (s3://bucket/key) to set metadata for.
+            copy_kwargs: Additional parameters to use for the underlying
+                CopyObject API call.
+            **kw_args: Key-value pairs to set, where the values must be
+                strings. Does not alter existing fields, unless the field
+                appears here - if the value is None, delete the field.
+
+        Example:
+            >>> fs = S3FileSystem()
+            >>> fs.setxattr("s3://bucket/key", attribute_1="value1")
+        """
+        bucket, key, version_id = self.parse_path(path)
+        if not key:
+            raise ValueError("Cannot set metadata of a bucket.")
+        kw_args = {k.replace("_", "-"): v for k, v in kw_args.items()}
+        metadata = self.metadata(path)
+        metadata.update(**kw_args)
+        # Remove all keys that are None.
+        for kw_key in kw_args:
+            if kw_args[kw_key] is None:
+                metadata.pop(kw_key, None)
+
+        copy_source: dict[str, Any] = {"Bucket": bucket, "Key": key}
+        if version_id:
+            copy_source.update({"VersionId": version_id})
+
+        _logger.debug("Set object metadata: s3://%s/%s?versionId=%s", bucket, key, version_id)
+        self._call(
+            self._client.copy_object,
+            CopySource=copy_source,
+            Bucket=bucket,
+            Key=key,
+            Metadata=metadata,
+            MetadataDirective="REPLACE",
+            **(copy_kwargs if copy_kwargs else {}),
+        )
+        self.invalidate_cache(path)
+
+    def get_tags(self, path: str) -> dict[str, str]:
+        """Retrieve the tag key/values for the given path.
+
+        Args:
+            path: S3 path (s3://bucket/key) to get tags for.
+
+        Returns:
+            Dictionary mapping tag keys to tag values.
+        """
+        bucket, key, version_id = self.parse_path(path)
+        if not key:
+            raise ValueError("Cannot get tags of a bucket.")
+        request: dict[str, Any] = {"Bucket": bucket, "Key": key}
+        if version_id:
+            request.update({"VersionId": version_id})
+
+        _logger.debug("Get object tagging: s3://%s/%s?versionId=%s", bucket, key, version_id)
+        response = self._call(
+            self._client.get_object_tagging,
+            **request,
+        )
+        return {v["Key"]: v["Value"] for v in response["TagSet"]}
+
+    def put_tags(self, path: str, tags: dict[str, str], mode: str = "o") -> None:
+        """Set the tags for the given existing key.
+
+        Tags are a str:str mapping that can be attached to any key, distinct
+        from the user-defined metadata, which is usually set at key creation
+        time. See
+        https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html
+
+        Args:
+            path: S3 path (s3://bucket/key) of the existing key to attach
+                tags to.
+            tags: Tags to apply.
+            mode: One of 'o' or 'm'. 'o' will over-write any existing tags.
+                'm' will merge in new tags with existing tags, which incurs
+                two remote calls.
+        """
+        bucket, key, version_id = self.parse_path(path)
+        if not key:
+            raise ValueError("Cannot put tags of a bucket.")
+        if mode == "m":
+            existing_tags = self.get_tags(path)
+            existing_tags.update(tags)
+            new_tags = [{"Key": k, "Value": v} for k, v in existing_tags.items()]
+        elif mode == "o":
+            new_tags = [{"Key": k, "Value": v} for k, v in tags.items()]
+        else:
+            raise ValueError(f"Mode must be {{'o', 'm'}}, not {mode}.")
+        request: dict[str, Any] = {
+            "Bucket": bucket,
+            "Key": key,
+            "Tagging": {"TagSet": new_tags},
+        }
+        if version_id:
+            request.update({"VersionId": version_id})
+
+        _logger.debug("Put object tagging: s3://%s/%s?versionId=%s", bucket, key, version_id)
+        self._call(
+            self._client.put_object_tagging,
+            **request,
+        )
+
+    def chmod(self, path: str, acl: str, recursive: bool = False, **kwargs) -> None:
+        """Set the Access Control on a bucket/key.
+
+        See https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl
+
+        Args:
+            path: S3 path (s3://bucket or s3://bucket/key) to set the ACL on.
+            acl: The value of the canned ACL to apply.
+            recursive: Whether to apply the ACL to all keys below the given
+                path too.
+            **kwargs: Additional parameters passed to the PutObjectAcl or
+                PutBucketAcl API.
+        """
+        bucket, key, version_id = self.parse_path(path)
+        if recursive:
+            for p in self.find(path, withdirs=False):
+                self.chmod(p, acl, recursive=False, **kwargs)
+        elif key:
+            if acl not in self.OBJECT_ACLS:
+                raise ValueError(f"ACL not in {self.OBJECT_ACLS}.")
+            request: dict[str, Any] = {"Bucket": bucket, "Key": key, "ACL": acl}
+            if version_id:
+                request.update({"VersionId": version_id})
+
+            _logger.debug("Put object acl: s3://%s/%s?versionId=%s", bucket, key, version_id)
+            self._call(
+                self._client.put_object_acl,
+                **request,
+                **kwargs,
+            )
+        if not key:
+            if acl not in self.BUCKET_ACLS:
+                raise ValueError(f"ACL not in {self.BUCKET_ACLS}.")
+
+            _logger.debug("Put bucket acl: s3://%s", bucket)
+            self._call(
+                self._client.put_bucket_acl,
+                Bucket=bucket,
+                ACL=acl,
+                **kwargs,
+            )
+
+    def list_multipart_uploads(self, path: str) -> list[S3MultipartUpload]:
+        """List in-progress (incomplete) multipart uploads in a bucket.
+
+        Incomplete multipart uploads continue to accrue storage costs until
+        they are completed or aborted. Use :meth:`clear_multipart_uploads`
+        to abort all of them.
+
+        Args:
+            path: S3 bucket name or path (e.g., "bucket" or "s3://bucket").
+
+        Returns:
+            List of S3MultipartUpload instances describing the in-progress
+            multipart uploads.
+        """
+        bucket, _, _ = self.parse_path(path)
+
+        _logger.debug("List multipart uploads: s3://%s", bucket)
+        uploads: list[S3MultipartUpload] = []
+        next_key_marker: str | None = None
+        next_upload_id_marker: str | None = None
+        while True:
+            request: dict[str, Any] = {"Bucket": bucket}
+            if next_key_marker:
+                request.update(
+                    {"KeyMarker": next_key_marker, "UploadIdMarker": next_upload_id_marker}
+                )
+            response = self._call(
+                self._client.list_multipart_uploads,
+                **request,
+            )
+            uploads.extend(
+                S3MultipartUpload({**u, "Bucket": bucket}) for u in response.get("Uploads", [])
+            )
+            if not response.get("IsTruncated"):
+                break
+            next_key_marker = response.get("NextKeyMarker")
+            next_upload_id_marker = response.get("NextUploadIdMarker")
+        return uploads
+
+    def clear_multipart_uploads(self, path: str) -> None:
+        """Abort any incomplete multipart uploads in the bucket.
+
+        Args:
+            path: S3 bucket name or path (e.g., "bucket" or "s3://bucket").
+        """
+        bucket, _, _ = self.parse_path(path)
+        for upload in self.list_multipart_uploads(bucket):
+            self._call(
+                self._client.abort_multipart_upload,
+                Bucket=bucket,
+                Key=upload.key,
+                UploadId=upload.upload_id,
+            )
+
     def created(self, path: str) -> datetime:
         return self.modified(path)
 
@@ -1099,6 +1468,34 @@ class S3FileSystem(AbstractFileSystem):
             while path:
                 self.dircache.pop(path, None)
                 path = self._parent(path)
+
+    def _ls_from_cache(self, path: str) -> list[S3Object] | S3Object | None:
+        """Check the dircache for a cached entry of the path.
+
+        fsspec's implementation assumes every dircache value is a listing,
+        but S3FileSystem also caches a single S3Object under the object's own
+        path (HeadObject/HeadBucket results). Guard the parent lookup so that
+        looking up a child path of a cached object does not fail, and fall
+        through to the S3 API instead.
+        """
+        cache = self.dircache.get(path.rstrip("/"))
+        if cache is not None:
+            return cast("list[S3Object] | S3Object", cache)
+        parent_cache = self.dircache.get(self._parent(path))
+        if isinstance(parent_cache, list):
+            files = [
+                f
+                for f in parent_cache
+                if f["name"] == path
+                or (
+                    f["name"] == path.rstrip("/")
+                    and f["type"] == S3ObjectType.S3_OBJECT_TYPE_DIRECTORY
+                )
+            ]
+            if files:
+                return files
+            raise FileNotFoundError(path)
+        return None
 
     def _open(
         self,
@@ -1277,9 +1674,12 @@ class S3FileSystem(AbstractFileSystem):
 
     def _call(self, method: str | Callable[..., Any], **kwargs) -> dict[str, Any]:
         func = getattr(self._client, method) if isinstance(method, str) else method
-        response = retry_api_call(
-            func, config=self._retry_config, logger=_logger, **kwargs, **self.request_kwargs
-        )
+        try:
+            response = retry_api_call(
+                func, config=self._retry_config, logger=_logger, **kwargs, **self.request_kwargs
+            )
+        except botocore.exceptions.ClientError as e:
+            raise translate_client_error(e) from e
         return cast(dict[str, Any], response)
 
 
@@ -1518,6 +1918,59 @@ class S3File(AbstractBufferedFile):
 
         self.multipart_upload = None
         self.multipart_upload_parts = []
+
+    def url(self, expiration: int = 3600, **kwargs) -> str:
+        """Generate a presigned HTTP URL to read this file (if it already exists).
+
+        Args:
+            expiration: URL expiration time in seconds. Defaults to 3600 (1 hour).
+            **kwargs: Additional parameters passed to :meth:`S3FileSystem.sign`.
+
+        Returns:
+            Presigned URL string that provides temporary access to the S3 object.
+        """
+        return cast(str, self.fs.sign(self.path, expiration=expiration, **kwargs))
+
+    def metadata(self, **kwargs) -> dict[str, Any]:
+        """Return the user-defined metadata of the file.
+
+        See :meth:`S3FileSystem.metadata`.
+
+        Args:
+            **kwargs: Additional parameters passed to the HeadObject API.
+
+        Returns:
+            Dictionary of the user-defined metadata.
+        """
+        return cast(dict[str, Any], self.fs.metadata(self.path, **kwargs))
+
+    def getxattr(self, xattr_name: str, **kwargs) -> Any:
+        """Get an attribute from the user-defined metadata of the file.
+
+        See :meth:`S3FileSystem.getxattr`.
+
+        Args:
+            xattr_name: The name of the attribute.
+            **kwargs: Additional parameters passed to the HeadObject API.
+
+        Returns:
+            The value of the attribute, or None if the attribute is not set.
+        """
+        return self.fs.getxattr(self.path, xattr_name, **kwargs)
+
+    def setxattr(self, copy_kwargs: dict[str, Any] | None = None, **kwargs) -> None:
+        """Set the user-defined metadata of the file.
+
+        See :meth:`S3FileSystem.setxattr`.
+
+        Args:
+            copy_kwargs: Additional parameters to use for the underlying
+                CopyObject API call.
+            **kwargs: Key-value pairs of metadata to set.
+        """
+        if self.writable():
+            raise NotImplementedError("Cannot update metadata while the file is open for writing.")
+        self.fs.setxattr(self.path, copy_kwargs=copy_kwargs, **kwargs)
 
     def _fetch_range(self, start: int, end: int) -> bytes:
         ranges = self._get_ranges(

--- a/pyathena/filesystem/s3.py
+++ b/pyathena/filesystem/s3.py
@@ -22,7 +22,7 @@ from fsspec.spec import AbstractBufferedFile
 from fsspec.utils import tokenize
 
 import pyathena
-from pyathena.filesystem.s3_errors import translate_client_error
+from pyathena.filesystem.s3_errors import S3ClientError
 from pyathena.filesystem.s3_executor import S3Executor, S3ThreadPoolExecutor
 from pyathena.filesystem.s3_object import (
     S3CompleteMultipartUpload,
@@ -1707,7 +1707,7 @@ class S3FileSystem(AbstractFileSystem):
                 func, config=self._retry_config, logger=_logger, **kwargs, **self.request_kwargs
             )
         except botocore.exceptions.ClientError as e:
-            raise translate_client_error(e) from e
+            raise S3ClientError(e).os_error from e
         return cast(dict[str, Any], response)
 
 

--- a/pyathena/filesystem/s3.py
+++ b/pyathena/filesystem/s3.py
@@ -124,6 +124,8 @@ class S3FileSystem(AbstractFileSystem):
         default_cache_type: str | None = None,
         max_workers: int = (cpu_count() or 1) * 5,
         s3_additional_kwargs=None,
+        allow_bucket_creation: bool = False,
+        allow_bucket_deletion: bool = False,
         *args,
         **kwargs,
     ) -> None:
@@ -145,6 +147,8 @@ class S3FileSystem(AbstractFileSystem):
         self.default_cache_type = default_cache_type if default_cache_type else "bytes"
         self.max_workers = max_workers
         self.s3_additional_kwargs = s3_additional_kwargs if s3_additional_kwargs else {}
+        self.allow_bucket_creation = allow_bucket_creation
+        self.allow_bucket_deletion = allow_bucket_deletion
 
         requester_pays = kwargs.pop("requester_pays", False)
         self.request_kwargs = {"RequestPayer": "requester"} if requester_pays else {}
@@ -757,6 +761,10 @@ class S3FileSystem(AbstractFileSystem):
         bucket does not exist yet), and does nothing for key prefixes under
         an existing bucket.
 
+        Bucket lifecycle operations are disabled by default because they are
+        infrastructure-level changes; pass ``allow_bucket_creation=True`` to
+        the filesystem constructor to enable bucket creation.
+
         Args:
             path: S3 path (e.g., "s3://bucket" or "s3://bucket/prefix").
             create_parents: If True, create the bucket when it does not exist,
@@ -770,6 +778,8 @@ class S3FileSystem(AbstractFileSystem):
             FileExistsError: If the path is a bucket that already exists.
             FileNotFoundError: If the bucket does not exist and
                 ``create_parents`` is False.
+            PermissionError: If the bucket would be created but bucket
+                creation is not enabled on this filesystem instance.
             ValueError: If the ACL is invalid or the path is empty.
         """
         path = self._strip_protocol(path).rstrip("/")
@@ -782,6 +792,11 @@ class S3FileSystem(AbstractFileSystem):
                 raise FileExistsError(bucket)
             # Do nothing as the bucket already exists.
         elif not key or create_parents:
+            if not self.allow_bucket_creation:
+                raise PermissionError(
+                    "Bucket creation is disabled. "
+                    "Set allow_bucket_creation=True on the filesystem to enable it."
+                )
             acl = kwargs.pop("acl", "")
             if acl and acl not in self.BUCKET_ACLS:
                 raise ValueError(f"ACL not in {self.BUCKET_ACLS}.")
@@ -830,6 +845,10 @@ class S3FileSystem(AbstractFileSystem):
         S3 has no real directories below the bucket level, so only bucket
         paths can be removed.
 
+        Bucket lifecycle operations are disabled by default because they are
+        infrastructure-level changes; pass ``allow_bucket_deletion=True`` to
+        the filesystem constructor to enable bucket deletion.
+
         Args:
             path: S3 bucket path (e.g., "s3://bucket").
 
@@ -838,6 +857,8 @@ class S3FileSystem(AbstractFileSystem):
                 may have meant ``rm(path, recursive=True)``.
             FileNotFoundError: If the path contains a key that does not exist,
                 or the bucket does not exist.
+            PermissionError: If bucket deletion is not enabled on this
+                filesystem instance.
             OSError: If the bucket is not empty.
         """
         path = self._strip_protocol(path).rstrip("/")
@@ -847,6 +868,11 @@ class S3FileSystem(AbstractFileSystem):
                 # The user may have meant rm(path, recursive=True).
                 raise FileExistsError(path)
             raise FileNotFoundError(path)
+        if not self.allow_bucket_deletion:
+            raise PermissionError(
+                "Bucket deletion is disabled. "
+                "Set allow_bucket_deletion=True on the filesystem to enable it."
+            )
 
         _logger.debug("Delete bucket: s3://%s", bucket)
         self._call(

--- a/pyathena/filesystem/s3.py
+++ b/pyathena/filesystem/s3.py
@@ -801,7 +801,9 @@ class S3FileSystem(AbstractFileSystem):
                 )
             except botocore.exceptions.ParamValidationError as e:
                 raise ValueError(f"Bucket create failed {bucket!r}: {e}") from e
-            self.invalidate_cache("")
+            # invalidate_cache walks parent paths and never pops the root
+            # entry itself, so evict the cached bucket listing directly.
+            self.dircache.pop("", None)
             self.invalidate_cache(bucket)
         else:
             # Raises FileNotFoundError if the bucket does not exist
@@ -852,7 +854,9 @@ class S3FileSystem(AbstractFileSystem):
             Bucket=bucket,
         )
         self.invalidate_cache(bucket)
-        self.invalidate_cache("")
+        # invalidate_cache walks parent paths and never pops the root
+        # entry itself, so evict the cached bucket listing directly.
+        self.dircache.pop("", None)
 
     def touch(self, path: str, truncate: bool = True, **kwargs) -> dict[str, Any]:
         bucket, key, version_id = self.parse_path(path)
@@ -1210,8 +1214,8 @@ class S3FileSystem(AbstractFileSystem):
             **kwargs: Additional parameters passed to the HeadObject API.
 
         Returns:
-            Dictionary of the user-defined metadata with the keys' underscores
-            replaced by hyphens.
+            Dictionary of the user-defined metadata. The keys are returned
+            as stored in S3 (S3 normalizes them to lowercase).
         """
         bucket, key, version_id = self.parse_path(path)
         if not key:
@@ -1226,25 +1230,20 @@ class S3FileSystem(AbstractFileSystem):
             **request,
             **kwargs,
         )
-        return {k.replace("_", "-"): v for k, v in response["Metadata"].items()}
+        return cast(dict[str, Any], response["Metadata"])
 
     def getxattr(self, path: str, attr_name: str, **kwargs) -> Any:
         """Get an attribute from the user-defined metadata of the path.
 
         Args:
             path: S3 path (s3://bucket/key) to get the attribute for.
-            attr_name: The name of the attribute. Underscores are replaced
-                by hyphens to match the metadata key format.
+            attr_name: The name of the attribute.
             **kwargs: Additional parameters passed to :meth:`metadata`.
 
         Returns:
             The value of the attribute, or None if the attribute is not set.
         """
-        attr_name = attr_name.replace("_", "-")
-        xattr = self.metadata(path, **kwargs)
-        if attr_name in xattr:
-            return xattr[attr_name]
-        return None
+        return self.metadata(path, **kwargs).get(attr_name)
 
     def setxattr(self, path: str, copy_kwargs: dict[str, Any] | None = None, **kw_args) -> None:
         """Set the user-defined metadata of the path.
@@ -1259,17 +1258,20 @@ class S3FileSystem(AbstractFileSystem):
             copy_kwargs: Additional parameters to use for the underlying
                 CopyObject API call.
             **kw_args: Key-value pairs to set, where the values must be
-                strings. Does not alter existing fields, unless the field
-                appears here - if the value is None, delete the field.
+                strings. The keys are used as-is; names that are not valid
+                Python identifiers (e.g., containing hyphens) can be passed
+                by unpacking a dictionary. Does not alter existing fields,
+                unless the field appears here - if the value is None, delete
+                the field.
 
         Example:
             >>> fs = S3FileSystem()
-            >>> fs.setxattr("s3://bucket/key", attribute_1="value1")
+            >>> fs.setxattr("s3://bucket/key", attribute1="value1")
+            >>> fs.setxattr("s3://bucket/key", **{"attribute-2": "value2"})
         """
         bucket, key, version_id = self.parse_path(path)
         if not key:
             raise ValueError("Cannot set metadata of a bucket.")
-        kw_args = {k.replace("_", "-"): v for k, v in kw_args.items()}
         metadata = self.metadata(path)
         metadata.update(**kw_args)
         # Remove all keys that are None.
@@ -1371,12 +1373,16 @@ class S3FileSystem(AbstractFileSystem):
                 PutBucketAcl API.
         """
         bucket, key, version_id = self.parse_path(path)
+        # Validate before any ACL is applied so that a recursive call cannot
+        # partially apply object ACLs and then fail on the bucket ACL.
+        if not key and acl not in self.BUCKET_ACLS:
+            raise ValueError(f"ACL not in {self.BUCKET_ACLS}.")
+        if key and acl not in self.OBJECT_ACLS:
+            raise ValueError(f"ACL not in {self.OBJECT_ACLS}.")
         if recursive:
             for p in self.find(path, withdirs=False):
                 self.chmod(p, acl, recursive=False, **kwargs)
         elif key:
-            if acl not in self.OBJECT_ACLS:
-                raise ValueError(f"ACL not in {self.OBJECT_ACLS}.")
             request: dict[str, Any] = {"Bucket": bucket, "Key": key, "ACL": acl}
             if version_id:
                 request.update({"VersionId": version_id})
@@ -1388,9 +1394,6 @@ class S3FileSystem(AbstractFileSystem):
                 **kwargs,
             )
         if not key:
-            if acl not in self.BUCKET_ACLS:
-                raise ValueError(f"ACL not in {self.BUCKET_ACLS}.")
-
             _logger.debug("Put bucket acl: s3://%s", bucket)
             self._call(
                 self._client.put_bucket_acl,
@@ -1407,20 +1410,24 @@ class S3FileSystem(AbstractFileSystem):
         to abort all of them.
 
         Args:
-            path: S3 bucket name or path (e.g., "bucket" or "s3://bucket").
+            path: S3 bucket or prefix path (e.g., "bucket", "s3://bucket" or
+                "s3://bucket/prefix"). If the path contains a key prefix,
+                only the uploads under that prefix are listed.
 
         Returns:
             List of S3MultipartUpload instances describing the in-progress
             multipart uploads.
         """
-        bucket, _, _ = self.parse_path(path)
+        bucket, key, _ = self.parse_path(path)
 
-        _logger.debug("List multipart uploads: s3://%s", bucket)
+        _logger.debug("List multipart uploads: s3://%s/%s", bucket, key)
         uploads: list[S3MultipartUpload] = []
         next_key_marker: str | None = None
         next_upload_id_marker: str | None = None
         while True:
             request: dict[str, Any] = {"Bucket": bucket}
+            if key:
+                request.update({"Prefix": key})
             if next_key_marker:
                 request.update(
                     {"KeyMarker": next_key_marker, "UploadIdMarker": next_upload_id_marker}
@@ -1436,16 +1443,20 @@ class S3FileSystem(AbstractFileSystem):
                 break
             next_key_marker = response.get("NextKeyMarker")
             next_upload_id_marker = response.get("NextUploadIdMarker")
+            if not next_key_marker or not next_upload_id_marker:
+                break
         return uploads
 
     def clear_multipart_uploads(self, path: str) -> None:
         """Abort any incomplete multipart uploads in the bucket.
 
         Args:
-            path: S3 bucket name or path (e.g., "bucket" or "s3://bucket").
+            path: S3 bucket or prefix path (e.g., "bucket", "s3://bucket" or
+                "s3://bucket/prefix"). If the path contains a key prefix,
+                only the uploads under that prefix are aborted.
         """
         bucket, _, _ = self.parse_path(path)
-        for upload in self.list_multipart_uploads(bucket):
+        for upload in self.list_multipart_uploads(path):
             self._call(
                 self._client.abort_multipart_upload,
                 Bucket=bucket,

--- a/pyathena/filesystem/s3.py
+++ b/pyathena/filesystem/s3.py
@@ -26,6 +26,7 @@ from pyathena.filesystem.s3_errors import S3ClientError
 from pyathena.filesystem.s3_executor import S3Executor, S3ThreadPoolExecutor
 from pyathena.filesystem.s3_object import (
     S3CompleteMultipartUpload,
+    S3Metadata,
     S3MultipartUpload,
     S3MultipartUploadPart,
     S3Object,
@@ -1232,16 +1233,18 @@ class S3FileSystem(AbstractFileSystem):
             **request,
         )
 
-    def metadata(self, path: str, **kwargs) -> dict[str, Any]:
-        """Return the user-defined metadata (``x-amz-meta-*``) of the path.
+    def metadata(self, path: str, **kwargs) -> S3Metadata:
+        """Return the metadata of the path.
 
         Args:
             path: S3 path (s3://bucket/key) to get metadata for.
             **kwargs: Additional parameters passed to the HeadObject API.
 
         Returns:
-            Dictionary of the user-defined metadata. The keys are returned
-            as stored in S3 (S3 normalizes them to lowercase).
+            S3Metadata, which behaves as a read-only mapping of the
+            user-defined metadata (``x-amz-meta-*``) and exposes the
+            system-defined metadata (content type, encryption settings,
+            etc.) as typed properties.
         """
         bucket, key, version_id = self.parse_path(path)
         if not key:
@@ -1256,9 +1259,9 @@ class S3FileSystem(AbstractFileSystem):
             **request,
             **kwargs,
         )
-        return cast(dict[str, Any], response["Metadata"])
+        return S3Metadata(response)
 
-    def getxattr(self, path: str, attr_name: str, **kwargs) -> Any:
+    def getxattr(self, path: str, attr_name: str, **kwargs) -> str | None:
         """Get an attribute from the user-defined metadata of the path.
 
         Args:
@@ -1298,7 +1301,7 @@ class S3FileSystem(AbstractFileSystem):
         bucket, key, version_id = self.parse_path(path)
         if not key:
             raise ValueError("Cannot set metadata of a bucket.")
-        metadata = self.metadata(path)
+        metadata = dict(self.metadata(path))
         for k, v in kw_args.items():
             if v is None:
                 metadata.pop(k, None)
@@ -1984,8 +1987,8 @@ class S3File(AbstractBufferedFile):
         """
         return cast(str, self.fs.sign(self.path, expiration=expiration, **kwargs))
 
-    def metadata(self, **kwargs) -> dict[str, Any]:
-        """Return the user-defined metadata of the file.
+    def metadata(self, **kwargs) -> S3Metadata:
+        """Return the metadata of the file.
 
         See :meth:`S3FileSystem.metadata`.
 
@@ -1993,11 +1996,13 @@ class S3File(AbstractBufferedFile):
             **kwargs: Additional parameters passed to the HeadObject API.
 
         Returns:
-            Dictionary of the user-defined metadata.
+            S3Metadata, which behaves as a read-only mapping of the
+            user-defined metadata and exposes the system-defined metadata
+            as typed properties.
         """
         return self.fs.metadata(self.path, **kwargs)
 
-    def getxattr(self, xattr_name: str, **kwargs) -> Any:
+    def getxattr(self, xattr_name: str, **kwargs) -> str | None:
         """Get an attribute from the user-defined metadata of the file.
 
         See :meth:`S3FileSystem.getxattr`.

--- a/pyathena/filesystem/s3.py
+++ b/pyathena/filesystem/s3.py
@@ -53,15 +53,24 @@ class S3FileSystem(AbstractFileSystem):
     - Listing objects and directories
     - Reading and writing files
     - Copying and moving objects
-    - Creating and removing directories
-    - Multipart uploads for large files
+    - Reading and writing object metadata, tags, and canned ACLs
+    - Multipart uploads for large files, including management of
+      incomplete uploads
+    - Creating and removing buckets (disabled by default; see
+      ``allow_bucket_creation`` / ``allow_bucket_deletion``)
     - Various S3 storage classes and encryption options
+    - Translating S3 error responses into standard Python exceptions
+      (e.g., ``404`` -> ``FileNotFoundError``, ``403`` -> ``PermissionError``)
 
     Attributes:
         session: The boto3 session used for S3 operations.
         client: The S3 client for direct API calls.
         config: Boto3 configuration for the client.
         retry_config: Configuration for retry behavior on failed operations.
+        allow_bucket_creation: Whether mkdir/makedirs may create buckets.
+            Defaults to False.
+        allow_bucket_deletion: Whether rmdir may delete buckets.
+            Defaults to False.
 
     Example:
         >>> from pyathena.filesystem.s3 import S3FileSystem
@@ -829,10 +838,19 @@ class S3FileSystem(AbstractFileSystem):
     def makedirs(self, path: str, exist_ok: bool = False) -> None:
         """Recursively create a directory, creating the bucket if necessary.
 
+        Creating the bucket requires ``allow_bucket_creation=True`` on the
+        filesystem constructor; see :meth:`mkdir`.
+
         Args:
             path: S3 path (e.g., "s3://bucket" or "s3://bucket/prefix").
             exist_ok: If False, raise FileExistsError when the path is a
                 bucket that already exists.
+
+        Raises:
+            FileExistsError: If the path is a bucket that already exists and
+                ``exist_ok`` is False.
+            PermissionError: If the bucket would be created but bucket
+                creation is not enabled on this filesystem instance.
         """
         try:
             self.mkdir(path, create_parents=True)

--- a/pyathena/filesystem/s3.py
+++ b/pyathena/filesystem/s3.py
@@ -806,17 +806,17 @@ class S3FileSystem(AbstractFileSystem):
             self.dircache.pop("", None)
             self.invalidate_cache(bucket)
         else:
-            # Raises FileNotFoundError if the bucket does not exist
+            # exists() has already confirmed the bucket does not exist,
             # and it is not requested to be created.
-            self.ls(bucket)
+            raise FileNotFoundError(bucket)
 
     def makedirs(self, path: str, exist_ok: bool = False) -> None:
         """Recursively create a directory, creating the bucket if necessary.
 
         Args:
             path: S3 path (e.g., "s3://bucket" or "s3://bucket/prefix").
-            exist_ok: If False, raise FileExistsError when the bucket
-                already exists.
+            exist_ok: If False, raise FileExistsError when the path is a
+                bucket that already exists.
         """
         try:
             self.mkdir(path, create_parents=True)
@@ -1273,11 +1273,11 @@ class S3FileSystem(AbstractFileSystem):
         if not key:
             raise ValueError("Cannot set metadata of a bucket.")
         metadata = self.metadata(path)
-        metadata.update(**kw_args)
-        # Remove all keys that are None.
-        for kw_key in kw_args:
-            if kw_args[kw_key] is None:
-                metadata.pop(kw_key, None)
+        for k, v in kw_args.items():
+            if v is None:
+                metadata.pop(k, None)
+            else:
+                metadata[k] = v
 
         copy_source: dict[str, Any] = {"Bucket": bucket, "Key": key}
         if version_id:
@@ -1387,7 +1387,11 @@ class S3FileSystem(AbstractFileSystem):
                 ]
                 for future in as_completed(futures):
                     future.result()
-        elif key:
+            if key:
+                # A key prefix is not an object itself; only the objects
+                # below it have ACLs.
+                return
+        if key:
             request: dict[str, Any] = {"Bucket": bucket, "Key": key, "ACL": acl}
             if version_id:
                 request.update({"VersionId": version_id})
@@ -1398,7 +1402,7 @@ class S3FileSystem(AbstractFileSystem):
                 **request,
                 **kwargs,
             )
-        if not key:
+        else:
             _logger.debug("Put bucket acl: s3://%s", bucket)
             self._call(
                 self._client.put_bucket_acl,
@@ -1460,14 +1464,22 @@ class S3FileSystem(AbstractFileSystem):
                 "s3://bucket/prefix"). If the path contains a key prefix,
                 only the uploads under that prefix are aborted.
         """
-        bucket, _, _ = self.parse_path(path)
-        for upload in self.list_multipart_uploads(path):
-            self._call(
-                self._client.abort_multipart_upload,
-                Bucket=bucket,
-                Key=upload.key,
-                UploadId=upload.upload_id,
-            )
+        uploads = self.list_multipart_uploads(path)
+        if not uploads:
+            return
+        with self._create_executor(max_workers=self.max_workers) as executor:
+            futures = [
+                executor.submit(
+                    self._call,
+                    self._client.abort_multipart_upload,
+                    Bucket=upload.bucket,
+                    Key=upload.key,
+                    UploadId=upload.upload_id,
+                )
+                for upload in uploads
+            ]
+            for future in as_completed(futures):
+                future.result()
 
     def created(self, path: str) -> datetime:
         return self.modified(path)
@@ -1700,6 +1712,8 @@ class S3FileSystem(AbstractFileSystem):
 
 
 class S3File(AbstractBufferedFile):
+    fs: S3FileSystem
+
     def __init__(
         self,
         fs: S3FileSystem,
@@ -1752,6 +1766,7 @@ class S3File(AbstractBufferedFile):
             raise ValueError(f"Block size must be >= {self.fs.MULTIPART_UPLOAD_MIN_PART_SIZE}MB.")
 
         self.append_block = False
+        self._details: S3Object | dict[str, Any]
         if "r" in mode:
             info = self.fs.info(self.path, version_id=self.version_id)
             if etag := info.get("etag"):
@@ -1803,9 +1818,7 @@ class S3File(AbstractBufferedFile):
                             bucket=self.bucket,
                             key=self.key,
                             copy_source=self.path,
-                            upload_id=cast(
-                                str, cast(S3MultipartUpload, self.multipart_upload).upload_id
-                            ),
+                            upload_id=cast(str, self.multipart_upload.upload_id),
                             part_number=i + 1,
                             copy_source_ranges=range_,
                         )
@@ -1817,9 +1830,7 @@ class S3File(AbstractBufferedFile):
                         bucket=self.bucket,
                         key=self.key,
                         copy_source=self.path,
-                        upload_id=cast(
-                            str, cast(S3MultipartUpload, self.multipart_upload).upload_id
-                        ),
+                        upload_id=cast(str, self.multipart_upload.upload_id),
                         part_number=1,
                     )
                 )
@@ -1958,7 +1969,7 @@ class S3File(AbstractBufferedFile):
         Returns:
             Dictionary of the user-defined metadata.
         """
-        return cast(dict[str, Any], self.fs.metadata(self.path, **kwargs))
+        return self.fs.metadata(self.path, **kwargs)
 
     def getxattr(self, xattr_name: str, **kwargs) -> Any:
         """Get an attribute from the user-defined metadata of the file.

--- a/pyathena/filesystem/s3_async.py
+++ b/pyathena/filesystem/s3_async.py
@@ -64,6 +64,8 @@ class AioS3FileSystem(AsyncFileSystem):
         default_cache_type: str | None = None,
         max_workers: int = (cpu_count() or 1) * 5,
         s3_additional_kwargs: dict[str, Any] | None = None,
+        allow_bucket_creation: bool = False,
+        allow_bucket_deletion: bool = False,
         asynchronous: bool = False,
         loop: Any | None = None,
         batch_size: int | None = None,
@@ -81,6 +83,8 @@ class AioS3FileSystem(AsyncFileSystem):
             default_cache_type=default_cache_type,
             max_workers=max_workers,
             s3_additional_kwargs=s3_additional_kwargs,
+            allow_bucket_creation=allow_bucket_creation,
+            allow_bucket_deletion=allow_bucket_deletion,
             **kwargs,
         )
         # Share dircache for cache coherence between async and sync instances

--- a/pyathena/filesystem/s3_async.py
+++ b/pyathena/filesystem/s3_async.py
@@ -10,7 +10,7 @@ from fsspec.callbacks import _DEFAULT_CALLBACK
 
 from pyathena.filesystem.s3 import S3File, S3FileSystem
 from pyathena.filesystem.s3_executor import S3AioExecutor
-from pyathena.filesystem.s3_object import S3MultipartUpload, S3Object
+from pyathena.filesystem.s3_object import S3Metadata, S3MultipartUpload, S3Object
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -335,10 +335,10 @@ class AioS3FileSystem(AsyncFileSystem):
     def sign(self, path: str, expiration: int = 3600, **kwargs) -> str:
         return cast(str, self._sync_fs.sign(path, expiration=expiration, **kwargs))
 
-    def metadata(self, path: str, **kwargs) -> dict[str, Any]:
+    def metadata(self, path: str, **kwargs) -> S3Metadata:
         return self._sync_fs.metadata(path, **kwargs)
 
-    def getxattr(self, path: str, attr_name: str, **kwargs) -> Any:
+    def getxattr(self, path: str, attr_name: str, **kwargs) -> str | None:
         return self._sync_fs.getxattr(path, attr_name, **kwargs)
 
     def setxattr(self, path: str, copy_kwargs: dict[str, Any] | None = None, **kwargs) -> None:

--- a/pyathena/filesystem/s3_async.py
+++ b/pyathena/filesystem/s3_async.py
@@ -10,7 +10,7 @@ from fsspec.callbacks import _DEFAULT_CALLBACK
 
 from pyathena.filesystem.s3 import S3File, S3FileSystem
 from pyathena.filesystem.s3_executor import S3AioExecutor
-from pyathena.filesystem.s3_object import S3Object
+from pyathena.filesystem.s3_object import S3MultipartUpload, S3Object
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -322,8 +322,38 @@ class AioS3FileSystem(AsyncFileSystem):
             **kwargs,
         )
 
+    async def _rmdir(self, path: str) -> None:
+        await asyncio.to_thread(self._sync_fs.rmdir, path)
+
+    def rmdir(self, path: str) -> None:
+        self._sync_fs.rmdir(path)
+
     def sign(self, path: str, expiration: int = 3600, **kwargs) -> str:
         return cast(str, self._sync_fs.sign(path, expiration=expiration, **kwargs))
+
+    def metadata(self, path: str, **kwargs) -> dict[str, Any]:
+        return self._sync_fs.metadata(path, **kwargs)
+
+    def getxattr(self, path: str, attr_name: str, **kwargs) -> Any:
+        return self._sync_fs.getxattr(path, attr_name, **kwargs)
+
+    def setxattr(self, path: str, copy_kwargs: dict[str, Any] | None = None, **kwargs) -> None:
+        self._sync_fs.setxattr(path, copy_kwargs=copy_kwargs, **kwargs)
+
+    def get_tags(self, path: str) -> dict[str, str]:
+        return self._sync_fs.get_tags(path)
+
+    def put_tags(self, path: str, tags: dict[str, str], mode: str = "o") -> None:
+        self._sync_fs.put_tags(path, tags, mode=mode)
+
+    def chmod(self, path: str, acl: str, recursive: bool = False, **kwargs) -> None:
+        self._sync_fs.chmod(path, acl, recursive=recursive, **kwargs)
+
+    def list_multipart_uploads(self, path: str) -> list[S3MultipartUpload]:
+        return self._sync_fs.list_multipart_uploads(path)
+
+    def clear_multipart_uploads(self, path: str) -> None:
+        self._sync_fs.clear_multipart_uploads(path)
 
     def checksum(self, path: str, **kwargs) -> int:
         return cast(int, self._sync_fs.checksum(path, **kwargs))

--- a/pyathena/filesystem/s3_errors.py
+++ b/pyathena/filesystem/s3_errors.py
@@ -1,0 +1,98 @@
+"""Translation of S3 error responses into standard Python exceptions.
+
+Maps botocore ``ClientError`` responses to the matching ``OSError`` subclasses
+so that filesystem operations raise natural Python exceptions
+(e.g. ``403`` -> ``PermissionError``, ``404`` -> ``FileNotFoundError``).
+
+Error codes are documented in
+https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
+"""
+
+from __future__ import annotations
+
+import errno
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import botocore.exceptions
+
+# S3 error codes that map to a specific Python built-in exception.
+_ERROR_CODE_TO_EXCEPTION: dict[str, type[Exception]] = {
+    "AccessDenied": PermissionError,
+    "AccountProblem": PermissionError,
+    "AllAccessDisabled": PermissionError,
+    "BucketAlreadyExists": FileExistsError,
+    "BucketAlreadyOwnedByYou": FileExistsError,
+    "ExpiredToken": PermissionError,
+    "InvalidAccessKeyId": PermissionError,
+    "InvalidObjectState": PermissionError,
+    "InvalidPayer": PermissionError,
+    "InvalidSecurity": PermissionError,
+    "NoSuchBucket": FileNotFoundError,
+    "NoSuchBucketPolicy": FileNotFoundError,
+    "NoSuchKey": FileNotFoundError,
+    "NoSuchLifecycleConfiguration": FileNotFoundError,
+    "NoSuchUpload": FileNotFoundError,
+    "NoSuchVersion": FileNotFoundError,
+    "NotSignedUp": PermissionError,
+    "RequestTimeout": TimeoutError,
+    "RequestTimeTooSkewed": PermissionError,
+    "SignatureDoesNotMatch": PermissionError,
+    "403": PermissionError,
+    "404": FileNotFoundError,
+}
+
+# S3 error codes that map to an OSError with a specific errno.
+_ERROR_CODE_TO_ERRNO: dict[str, int] = {
+    "BucketNotEmpty": errno.ENOTEMPTY,
+    "InternalError": errno.EIO,
+    "OperationAborted": errno.EBUSY,
+    "RestoreAlreadyInProgress": errno.EBUSY,
+    "ServiceUnavailable": errno.EBUSY,
+    "SlowDown": errno.EBUSY,
+    "MethodNotAllowed": errno.EPERM,
+}
+
+# Fallbacks by HTTP status code for error codes not listed above.
+_HTTP_STATUS_CODE_TO_ERRNO: dict[int, int] = {
+    400: errno.EINVAL,
+    405: errno.EPERM,
+    409: errno.EBUSY,
+    412: errno.EINVAL,
+    416: errno.EINVAL,
+    500: errno.EIO,
+    501: errno.ENOSYS,
+    503: errno.EBUSY,
+}
+
+
+def translate_client_error(error: botocore.exceptions.ClientError) -> Exception:
+    """Convert a botocore ClientError into a natural Python exception.
+
+    Args:
+        error: The client error raised by an S3 API call.
+
+    Returns:
+        An instantiated exception ready to be raised. The error is mapped by
+        its S3 error code first, then by its HTTP status code. If neither is
+        recognized, an ``OSError`` with the original error message is
+        returned. The original exception should be preserved by raising the
+        translated exception with ``raise ... from error``.
+
+    Note:
+        ``OSError`` specializes itself into a subclass for some errno values
+        (e.g., ``EPERM`` -> ``PermissionError``), so the returned exception
+        may be a subclass of ``OSError`` even for the errno-based mappings.
+    """
+    code = error.response.get("Error", {}).get("Code", "")
+    message = error.response.get("Error", {}).get("Message", str(error))
+
+    exception = _ERROR_CODE_TO_EXCEPTION.get(code)
+    if exception:
+        return exception(message)
+
+    errno_ = _ERROR_CODE_TO_ERRNO.get(code)
+    if errno_ is None:
+        status_code = error.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+        errno_ = _HTTP_STATUS_CODE_TO_ERRNO.get(status_code, errno.EIO)
+    return OSError(errno_, message)

--- a/pyathena/filesystem/s3_errors.py
+++ b/pyathena/filesystem/s3_errors.py
@@ -13,93 +13,129 @@ The mapping to Python exceptions is PyAthena's own.
 from __future__ import annotations
 
 import errno
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
     import botocore.exceptions
 
-# S3 error codes (https://docs.aws.amazon.com/AmazonS3/latest/API/API_Error.html)
-# that map to a specific Python built-in exception.
-# The "403" / "404" entries are not S3 error codes: HEAD requests
-# (HeadObject/HeadBucket) have no response body, so botocore reports the
-# HTTP status code as the error code instead.
-# https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html
-_ERROR_CODE_TO_EXCEPTION: dict[str, type[Exception]] = {
-    "AccessDenied": PermissionError,
-    "AccountProblem": PermissionError,
-    "AllAccessDisabled": PermissionError,
-    "BucketAlreadyExists": FileExistsError,
-    "BucketAlreadyOwnedByYou": FileExistsError,
-    "ExpiredToken": PermissionError,
-    "InvalidAccessKeyId": PermissionError,
-    "InvalidObjectState": PermissionError,
-    "InvalidPayer": PermissionError,
-    "InvalidSecurity": PermissionError,
-    "NoSuchBucket": FileNotFoundError,
-    "NoSuchBucketPolicy": FileNotFoundError,
-    "NoSuchKey": FileNotFoundError,
-    "NoSuchLifecycleConfiguration": FileNotFoundError,
-    "NoSuchUpload": FileNotFoundError,
-    "NoSuchVersion": FileNotFoundError,
-    "NotSignedUp": PermissionError,
-    "RequestTimeout": TimeoutError,
-    "RequestTimeTooSkewed": PermissionError,
-    "SignatureDoesNotMatch": PermissionError,
-    "403": PermissionError,
-    "404": FileNotFoundError,
-}
 
-# S3 error codes (https://docs.aws.amazon.com/AmazonS3/latest/API/API_Error.html)
-# that map to an OSError with a specific errno.
-_ERROR_CODE_TO_ERRNO: dict[str, int] = {
-    "BucketNotEmpty": errno.ENOTEMPTY,
-    "InternalError": errno.EIO,
-    "OperationAborted": errno.EBUSY,
-    "RestoreAlreadyInProgress": errno.EBUSY,
-    "ServiceUnavailable": errno.EBUSY,
-    "SlowDown": errno.EBUSY,
-}
+class S3ClientError:
+    """Represents an S3 error response with its translation to an OSError.
 
-# Fallbacks by HTTP status code for error codes not listed above.
-_HTTP_STATUS_CODE_TO_ERRNO: dict[int, int] = {
-    400: errno.EINVAL,
-    405: errno.EPERM,
-    409: errno.EBUSY,
-    412: errno.EINVAL,
-    416: errno.EINVAL,
-    500: errno.EIO,
-    501: errno.ENOSYS,
-    503: errno.EBUSY,
-}
+    Wraps a botocore ``ClientError`` and exposes the error response fields
+    as properties, along with :attr:`os_error`, the equivalent standard
+    Python exception. The error is mapped by its S3 error code first, then
+    by its HTTP status code; if neither is recognized, a generic ``OSError``
+    with the original error message is used.
 
-
-def translate_client_error(error: botocore.exceptions.ClientError) -> Exception:
-    """Convert a botocore ClientError into a natural Python exception.
-
-    Args:
-        error: The client error raised by an S3 API call.
-
-    Returns:
-        An instantiated exception ready to be raised. The error is mapped by
-        its S3 error code first, then by its HTTP status code. If neither is
-        recognized, an ``OSError`` with the original error message is
-        returned. The original exception should be preserved by raising the
-        translated exception with ``raise ... from error``.
-
-    Note:
-        ``OSError`` specializes itself into a subclass for some errno values
-        (e.g., ``EPERM`` -> ``PermissionError``), so the returned exception
-        may be a subclass of ``OSError`` even for the errno-based mappings.
+    Example:
+        >>> try:
+        ...     client.head_object(Bucket="bucket", Key="key")
+        ... except botocore.exceptions.ClientError as e:
+        ...     raise S3ClientError(e).os_error from e
     """
-    code = error.response.get("Error", {}).get("Code", "")
-    message = error.response.get("Error", {}).get("Message", str(error))
 
-    exception = _ERROR_CODE_TO_EXCEPTION.get(code)
-    if exception:
-        return exception(message)
+    # S3 error codes (https://docs.aws.amazon.com/AmazonS3/latest/API/API_Error.html)
+    # that map to a specific OSError subclass.
+    # The "403" / "404" entries are not S3 error codes: HEAD requests
+    # (HeadObject/HeadBucket) have no response body, so botocore reports the
+    # HTTP status code as the error code instead.
+    # https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html
+    _ERROR_CODE_TO_EXCEPTION: ClassVar[dict[str, type[OSError]]] = {
+        "AccessDenied": PermissionError,
+        "AccountProblem": PermissionError,
+        "AllAccessDisabled": PermissionError,
+        "BucketAlreadyExists": FileExistsError,
+        "BucketAlreadyOwnedByYou": FileExistsError,
+        "ExpiredToken": PermissionError,
+        "InvalidAccessKeyId": PermissionError,
+        "InvalidObjectState": PermissionError,
+        "InvalidPayer": PermissionError,
+        "InvalidSecurity": PermissionError,
+        "NoSuchBucket": FileNotFoundError,
+        "NoSuchBucketPolicy": FileNotFoundError,
+        "NoSuchKey": FileNotFoundError,
+        "NoSuchLifecycleConfiguration": FileNotFoundError,
+        "NoSuchUpload": FileNotFoundError,
+        "NoSuchVersion": FileNotFoundError,
+        "NotSignedUp": PermissionError,
+        "RequestTimeout": TimeoutError,
+        "RequestTimeTooSkewed": PermissionError,
+        "SignatureDoesNotMatch": PermissionError,
+        "403": PermissionError,
+        "404": FileNotFoundError,
+    }
 
-    errno_ = _ERROR_CODE_TO_ERRNO.get(code)
-    if errno_ is None:
+    # S3 error codes (https://docs.aws.amazon.com/AmazonS3/latest/API/API_Error.html)
+    # that map to an OSError with a specific errno.
+    _ERROR_CODE_TO_ERRNO: ClassVar[dict[str, int]] = {
+        "BucketNotEmpty": errno.ENOTEMPTY,
+        "InternalError": errno.EIO,
+        "OperationAborted": errno.EBUSY,
+        "RestoreAlreadyInProgress": errno.EBUSY,
+        "ServiceUnavailable": errno.EBUSY,
+        "SlowDown": errno.EBUSY,
+    }
+
+    # Fallbacks by HTTP status code for error codes not listed above.
+    _HTTP_STATUS_CODE_TO_ERRNO: ClassVar[dict[int, int]] = {
+        400: errno.EINVAL,
+        405: errno.EPERM,
+        409: errno.EBUSY,
+        412: errno.EINVAL,
+        416: errno.EINVAL,
+        500: errno.EIO,
+        501: errno.ENOSYS,
+        503: errno.EBUSY,
+    }
+
+    def __init__(self, error: botocore.exceptions.ClientError) -> None:
+        error_info = error.response.get("Error", {})
+        self._code: str = str(error_info.get("Code", ""))
+        self._message: str = str(error_info.get("Message", error))
         status_code = error.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
-        errno_ = _HTTP_STATUS_CODE_TO_ERRNO.get(status_code, errno.EIO)
-    return OSError(errno_, message)
+        self._http_status_code: int | None = int(status_code) if status_code is not None else None
+        self._os_error: OSError = self._translate()
+
+    def _translate(self) -> OSError:
+        exception = self._ERROR_CODE_TO_EXCEPTION.get(self._code)
+        if exception:
+            return exception(self._message)
+        errno_ = self._ERROR_CODE_TO_ERRNO.get(self._code)
+        if errno_ is None:
+            if self._http_status_code is not None:
+                errno_ = self._HTTP_STATUS_CODE_TO_ERRNO.get(self._http_status_code, errno.EIO)
+            else:
+                errno_ = errno.EIO
+        return OSError(errno_, self._message)
+
+    @property
+    def code(self) -> str:
+        """The S3 error code that uniquely identifies the error condition."""
+        return self._code
+
+    @property
+    def message(self) -> str:
+        """The error message returned by the server."""
+        return self._message
+
+    @property
+    def http_status_code(self) -> int | None:
+        """The HTTP status code of the error response."""
+        return self._http_status_code
+
+    @property
+    def os_error(self) -> OSError:
+        """The standard Python exception equivalent to this error response.
+
+        Resolved once at construction time. The exception is instantiated
+        and ready to be raised; raise it with ``raise ... from error`` to
+        preserve the original exception.
+
+        Note:
+            ``OSError`` specializes itself into a subclass for some errno
+            values (e.g., ``EPERM`` -> ``PermissionError``), so the returned
+            exception may be a subclass of ``OSError`` even for the
+            errno-based mappings.
+        """
+        return self._os_error

--- a/pyathena/filesystem/s3_errors.py
+++ b/pyathena/filesystem/s3_errors.py
@@ -4,8 +4,10 @@ Maps botocore ``ClientError`` responses to the matching ``OSError`` subclasses
 so that filesystem operations raise natural Python exceptions
 (e.g. ``403`` -> ``PermissionError``, ``404`` -> ``FileNotFoundError``).
 
-Error codes are documented in
-https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
+The error codes are taken from the official list of Amazon S3 error codes:
+https://docs.aws.amazon.com/AmazonS3/latest/API/API_Error.html
+(see also https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html).
+The mapping to Python exceptions is PyAthena's own.
 """
 
 from __future__ import annotations
@@ -16,7 +18,12 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import botocore.exceptions
 
-# S3 error codes that map to a specific Python built-in exception.
+# S3 error codes (https://docs.aws.amazon.com/AmazonS3/latest/API/API_Error.html)
+# that map to a specific Python built-in exception.
+# The "403" / "404" entries are not S3 error codes: HEAD requests
+# (HeadObject/HeadBucket) have no response body, so botocore reports the
+# HTTP status code as the error code instead.
+# https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html
 _ERROR_CODE_TO_EXCEPTION: dict[str, type[Exception]] = {
     "AccessDenied": PermissionError,
     "AccountProblem": PermissionError,
@@ -42,7 +49,8 @@ _ERROR_CODE_TO_EXCEPTION: dict[str, type[Exception]] = {
     "404": FileNotFoundError,
 }
 
-# S3 error codes that map to an OSError with a specific errno.
+# S3 error codes (https://docs.aws.amazon.com/AmazonS3/latest/API/API_Error.html)
+# that map to an OSError with a specific errno.
 _ERROR_CODE_TO_ERRNO: dict[str, int] = {
     "BucketNotEmpty": errno.ENOTEMPTY,
     "InternalError": errno.EIO,

--- a/pyathena/filesystem/s3_errors.py
+++ b/pyathena/filesystem/s3_errors.py
@@ -58,7 +58,6 @@ _ERROR_CODE_TO_ERRNO: dict[str, int] = {
     "RestoreAlreadyInProgress": errno.EBUSY,
     "ServiceUnavailable": errno.EBUSY,
     "SlowDown": errno.EBUSY,
-    "MethodNotAllowed": errno.EPERM,
 }
 
 # Fallbacks by HTTP status code for error codes not listed above.

--- a/pyathena/filesystem/s3_object.py
+++ b/pyathena/filesystem/s3_object.py
@@ -277,6 +277,27 @@ class S3PutObject:
         return copy.deepcopy(self.__dict__)
 
 
+class S3Owner:
+    """Represents the owner or initiator of an S3 object or multipart upload.
+
+    Attributes:
+        display_name: The display name of the owner.
+        id: The canonical user ID of the owner.
+    """
+
+    def __init__(self, response: dict[str, Any]) -> None:
+        self._display_name: str | None = response.get("DisplayName")
+        self._id: str | None = response.get("ID")
+
+    @property
+    def display_name(self) -> str | None:
+        return self._display_name
+
+    @property
+    def id(self) -> str | None:
+        return self._id
+
+
 class S3MultipartUpload:
     """Represents an S3 multipart upload operation.
 
@@ -309,6 +330,13 @@ class S3MultipartUpload:
         self._bucket_key_enabled = response.get("BucketKeyEnabled")
         self._request_charged = response.get("RequestCharged")
         self._checksum_algorithm = response.get("ChecksumAlgorithm")
+        # The following fields are returned by the ListMultipartUploads API.
+        self._initiated: datetime | None = response.get("Initiated")
+        self._storage_class: str | None = response.get("StorageClass")
+        owner = response.get("Owner")
+        self._owner: S3Owner | None = S3Owner(owner) if owner else None
+        initiator = response.get("Initiator")
+        self._initiator: S3Owner | None = S3Owner(initiator) if initiator else None
 
     @property
     def abort_date(self) -> datetime | None:
@@ -361,6 +389,22 @@ class S3MultipartUpload:
     @property
     def checksum_algorithm(self) -> str | None:
         return self._checksum_algorithm
+
+    @property
+    def initiated(self) -> datetime | None:
+        return self._initiated
+
+    @property
+    def storage_class(self) -> str | None:
+        return self._storage_class
+
+    @property
+    def owner(self) -> S3Owner | None:
+        return self._owner
+
+    @property
+    def initiator(self) -> S3Owner | None:
+        return self._initiator
 
 
 class S3MultipartUploadPart:

--- a/pyathena/filesystem/s3_object.py
+++ b/pyathena/filesystem/s3_object.py
@@ -236,13 +236,6 @@ class S3Metadata(Mapping[str, str]):
     def __len__(self) -> int:
         return len(self._user_metadata)
 
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, S3Metadata):
-            return self._user_metadata == other._user_metadata
-        if isinstance(other, Mapping):
-            return self._user_metadata == dict(other)
-        return NotImplemented
-
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self._user_metadata!r})"
 

--- a/pyathena/filesystem/s3_object.py
+++ b/pyathena/filesystem/s3_object.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 import logging
-from collections.abc import Iterator, MutableMapping
+from collections.abc import Iterator, Mapping, MutableMapping
 from datetime import datetime
 from typing import Any
 
@@ -180,6 +180,149 @@ class S3Object(MutableMapping[str, Any]):
             if field is not None:
                 fields[k] = field
         return fields
+
+
+class S3Metadata(Mapping[str, str]):
+    """Represents the metadata of an S3 object as returned by HeadObject.
+
+    Behaves as a read-only mapping of the user-defined metadata
+    (``x-amz-meta-*``, whose keys are arbitrary user-chosen strings), so it
+    is a drop-in for implementations that return the user-defined metadata
+    as a plain dictionary, and compares equal to such dictionaries. The
+    system-defined metadata (content type, encryption settings, storage
+    class, etc.) is exposed as typed properties.
+
+    Example:
+        >>> metadata = fs.metadata("s3://bucket/key")
+        >>> metadata["attr1"]  # user-defined metadata
+        'value1'
+        >>> metadata.content_type  # system-defined metadata
+        'text/plain'
+
+    See https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html
+    """
+
+    def __init__(self, response: dict[str, Any]) -> None:
+        self._cache_control: str | None = response.get("CacheControl")
+        self._content_disposition: str | None = response.get("ContentDisposition")
+        self._content_encoding: str | None = response.get("ContentEncoding")
+        self._content_language: str | None = response.get("ContentLanguage")
+        self._content_length: int | None = response.get("ContentLength")
+        self._content_type: str | None = response.get("ContentType")
+        self._etag: str | None = response.get("ETag")
+        self._expiration: str | None = response.get("Expiration")
+        self._expires: datetime | None = response.get("Expires")
+        self._last_modified: datetime | None = response.get("LastModified")
+        # https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html#API_HeadObject_ResponseSyntax
+        # Amazon S3 returns this header for all objects except for
+        # S3 Standard storage class objects.
+        self._storage_class: str = response.get(
+            "StorageClass", S3StorageClass.S3_STORAGE_CLASS_STANDARD
+        )
+        self._server_side_encryption: str | None = response.get("ServerSideEncryption")
+        self._sse_customer_algorithm: str | None = response.get("SSECustomerAlgorithm")
+        self._sse_kms_key_id: str | None = response.get("SSEKMSKeyId")
+        self._bucket_key_enabled: bool | None = response.get("BucketKeyEnabled")
+        self._website_redirect_location: str | None = response.get("WebsiteRedirectLocation")
+        self._version_id: str | None = response.get("VersionId")
+        self._user_metadata: dict[str, str] = response.get("Metadata", {})
+
+    def __getitem__(self, key: str) -> str:
+        return self._user_metadata[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._user_metadata)
+
+    def __len__(self) -> int:
+        return len(self._user_metadata)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, S3Metadata):
+            return self._user_metadata == other._user_metadata
+        if isinstance(other, Mapping):
+            return self._user_metadata == dict(other)
+        return NotImplemented
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self._user_metadata!r})"
+
+    @property
+    def cache_control(self) -> str | None:
+        return self._cache_control
+
+    @property
+    def content_disposition(self) -> str | None:
+        return self._content_disposition
+
+    @property
+    def content_encoding(self) -> str | None:
+        return self._content_encoding
+
+    @property
+    def content_language(self) -> str | None:
+        return self._content_language
+
+    @property
+    def content_length(self) -> int | None:
+        return self._content_length
+
+    @property
+    def content_type(self) -> str | None:
+        return self._content_type
+
+    @property
+    def etag(self) -> str | None:
+        return self._etag
+
+    @property
+    def expiration(self) -> str | None:
+        return self._expiration
+
+    @property
+    def expires(self) -> datetime | None:
+        return self._expires
+
+    @property
+    def last_modified(self) -> datetime | None:
+        return self._last_modified
+
+    @property
+    def storage_class(self) -> str:
+        return self._storage_class
+
+    @property
+    def server_side_encryption(self) -> str | None:
+        return self._server_side_encryption
+
+    @property
+    def sse_customer_algorithm(self) -> str | None:
+        return self._sse_customer_algorithm
+
+    @property
+    def sse_kms_key_id(self) -> str | None:
+        return self._sse_kms_key_id
+
+    @property
+    def bucket_key_enabled(self) -> bool | None:
+        return self._bucket_key_enabled
+
+    @property
+    def website_redirect_location(self) -> str | None:
+        return self._website_redirect_location
+
+    @property
+    def version_id(self) -> str | None:
+        return self._version_id
+
+    @property
+    def user_metadata(self) -> dict[str, str]:
+        """A copy of the user-defined metadata (``x-amz-meta-*``).
+
+        The keys are arbitrary user-chosen strings, returned as stored in S3
+        (S3 normalizes them to lowercase). The same key/value pairs are also
+        accessible directly through the mapping interface of this class.
+        """
+        return dict(self._user_metadata)
 
 
 class S3PutObject:

--- a/pyathena/filesystem/s3_object.py
+++ b/pyathena/filesystem/s3_object.py
@@ -447,9 +447,12 @@ class S3MultipartUpload:
         upload_id: Unique identifier for the multipart upload.
         server_side_encryption: Encryption method applied to the upload.
         abort_date/abort_rule_id: Lifecycle rule information for upload cleanup.
+        initiated/storage_class/owner/initiator: Fields returned by the
+            ListMultipartUploads API for in-progress uploads.
 
     Note:
-        Used internally by S3FileSystem for large file upload operations.
+        Used internally by S3FileSystem for large file upload operations,
+        and returned by ``S3FileSystem.list_multipart_uploads``.
     """
 
     def __init__(self, response: dict[str, Any]) -> None:

--- a/scripts/cloudformation/github_actions_oidc.yaml
+++ b/scripts/cloudformation/github_actions_oidc.yaml
@@ -104,12 +104,14 @@ Resources:
                 Action: [
                   "s3:GetBucketLocation",
                   "s3:GetObject",
+                  "s3:GetObjectTagging",
                   "s3:ListBucket",
                   "s3:ListBucketMultipartUploads",
                   "s3:ListMultipartUploadParts",
                   "s3:AbortMultipartUpload",
                   "s3:CreateBucket",
                   "s3:PutObject",
+                  "s3:PutObjectTagging",
                   "s3:PutBucketPublicAccessBlock",
                   "s3:DeleteObject"
                 ]

--- a/tests/pyathena/filesystem/test_s3.py
+++ b/tests/pyathena/filesystem/test_s3.py
@@ -130,6 +130,338 @@ class TestS3FileSystem:
         with pytest.raises(ValueError, match="Invalid S3 path format"):
             S3FileSystem.parse_path("s3a://bucket/path/to/obj?foo=bar")
 
+    @staticmethod
+    def _make_fs():
+        # Build a minimal S3FileSystem without touching AWS, bypassing
+        # __init__ which would require a boto3 client.
+        fs = S3FileSystem.__new__(S3FileSystem)
+        fs.dircache = {}
+        fs._client = mock.MagicMock()
+        fs._call = mock.MagicMock()
+        fs._retry_config = RetryConfig()
+        fs.request_kwargs = {}
+        fs.max_workers = 4
+        return fs
+
+    def test_call_translates_client_error(self):
+        fs = self._make_fs()
+        del fs._call  # Use the real method instead of the mock.
+        func = mock.MagicMock(
+            side_effect=botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}}, "HeadObject"
+            )
+        )
+        with pytest.raises(PermissionError, match="Access Denied"):
+            fs._call(func)
+
+    def test_ls_from_cache_with_cached_object(self):
+        fs = self._make_fs()
+        obj = S3Object(
+            init={
+                "ContentLength": 4,
+                "ContentType": None,
+                "StorageClass": S3StorageClass.S3_STORAGE_CLASS_STANDARD,
+                "ETag": '"etag"',
+                "LastModified": None,
+            },
+            type=S3ObjectType.S3_OBJECT_TYPE_FILE,
+            bucket="bucket",
+            key="key",
+        )
+        fs.dircache["bucket/key"] = obj
+
+        assert fs._ls_from_cache("bucket/key") is obj
+        # A child path of a cached object entry must not fail; it falls
+        # through to the S3 API instead (fsspec's implementation assumes
+        # every cache value is a listing and raises TypeError here).
+        assert fs._ls_from_cache("bucket/key/child") is None
+
+    def test_mkdir_creates_bucket(self):
+        fs = self._make_fs()
+        fs.exists = mock.MagicMock(return_value=False)
+        fs._client.meta.region_name = "ap-northeast-1"
+        fs.dircache[""] = ["stale-bucket-listing"]
+
+        fs.mkdir("s3://new-bucket")
+        fs._call.assert_called_once_with(
+            fs._client.create_bucket,
+            Bucket="new-bucket",
+            CreateBucketConfiguration={"LocationConstraint": "ap-northeast-1"},
+        )
+        # The cached bucket listing must be evicted.
+        assert "" not in fs.dircache
+
+    def test_mkdir_creates_bucket_in_us_east_1_without_location_constraint(self):
+        fs = self._make_fs()
+        fs.exists = mock.MagicMock(return_value=False)
+        fs._client.meta.region_name = "us-east-1"
+
+        fs.mkdir("s3://new-bucket")
+        fs._call.assert_called_once_with(fs._client.create_bucket, Bucket="new-bucket")
+
+    def test_mkdir_creates_bucket_with_acl(self):
+        fs = self._make_fs()
+        fs.exists = mock.MagicMock(return_value=False)
+        fs._client.meta.region_name = "us-east-1"
+
+        fs.mkdir("s3://new-bucket", acl="private")
+        fs._call.assert_called_once_with(
+            fs._client.create_bucket, Bucket="new-bucket", ACL="private"
+        )
+
+        with pytest.raises(ValueError, match="ACL not in"):
+            fs.mkdir("s3://another-bucket", acl="invalid-acl")
+
+    def test_mkdir_existing_bucket_raises(self):
+        fs = self._make_fs()
+        fs.exists = mock.MagicMock(return_value=True)
+
+        with pytest.raises(FileExistsError):
+            fs.mkdir("s3://bucket")
+        fs._call.assert_not_called()
+
+    def test_mkdir_key_under_existing_bucket_is_noop(self):
+        fs = self._make_fs()
+        fs.exists = mock.MagicMock(return_value=True)
+
+        fs.mkdir("s3://bucket/path/to/dir")
+        fs._call.assert_not_called()
+
+    def test_mkdir_key_without_create_parents_checks_bucket(self):
+        fs = self._make_fs()
+        fs.exists = mock.MagicMock(return_value=False)
+        fs.ls = mock.MagicMock(side_effect=FileNotFoundError("bucket"))
+
+        with pytest.raises(FileNotFoundError):
+            fs.mkdir("s3://bucket/path/to/dir", create_parents=False)
+        fs._call.assert_not_called()
+
+    def test_makedirs_exist_ok(self):
+        fs = self._make_fs()
+        fs.mkdir = mock.MagicMock(side_effect=FileExistsError("bucket"))
+
+        fs.makedirs("s3://bucket", exist_ok=True)
+        with pytest.raises(FileExistsError):
+            fs.makedirs("s3://bucket", exist_ok=False)
+
+    def test_rmdir_deletes_bucket(self):
+        fs = self._make_fs()
+        fs.dircache[""] = ["stale-bucket-listing"]
+
+        fs.rmdir("s3://bucket")
+        fs._call.assert_called_once_with(fs._client.delete_bucket, Bucket="bucket")
+        # The cached bucket listing must be evicted.
+        assert "" not in fs.dircache
+
+    def test_rmdir_key_raises(self):
+        fs = self._make_fs()
+        fs.exists = mock.MagicMock(return_value=True)
+        with pytest.raises(FileExistsError):
+            fs.rmdir("s3://bucket/existing-key")
+
+        fs.exists = mock.MagicMock(return_value=False)
+        with pytest.raises(FileNotFoundError):
+            fs.rmdir("s3://bucket/nonexistent-key")
+        fs._call.assert_not_called()
+
+    def test_metadata(self):
+        fs = self._make_fs()
+        fs._call.return_value = {"Metadata": {"foo_bar": "baz"}}
+
+        # The keys are returned as stored, without any transformation.
+        assert fs.metadata("s3://bucket/key") == {"foo_bar": "baz"}
+        fs._call.assert_called_once_with(fs._client.head_object, Bucket="bucket", Key="key")
+
+    def test_metadata_with_version_id(self):
+        fs = self._make_fs()
+        fs._call.return_value = {"Metadata": {}}
+
+        assert fs.metadata("s3://bucket/key?versionId=12345abcde") == {}
+        fs._call.assert_called_once_with(
+            fs._client.head_object, Bucket="bucket", Key="key", VersionId="12345abcde"
+        )
+
+    def test_metadata_bucket_raises(self):
+        fs = self._make_fs()
+        with pytest.raises(ValueError, match="Cannot get metadata"):
+            fs.metadata("s3://bucket")
+
+    def test_getxattr(self):
+        fs = self._make_fs()
+        fs.metadata = mock.MagicMock(return_value={"attr-1": "value1"})
+
+        # The attribute name is looked up as-is, without any transformation.
+        assert fs.getxattr("s3://bucket/key", "attr-1") == "value1"
+        assert fs.getxattr("s3://bucket/key", "attr_1") is None
+        assert fs.getxattr("s3://bucket/key", "missing") is None
+
+    def test_setxattr(self):
+        fs = self._make_fs()
+        fs.metadata = mock.MagicMock(return_value={"attr1": "value1", "attr2": "value2"})
+
+        # The keys are used as-is; hyphenated names can be passed by
+        # unpacking a dictionary.
+        fs.setxattr(
+            "s3://bucket/key",
+            copy_kwargs={"ContentType": "text/plain"},
+            attr2=None,
+            attr3="value3",
+            **{"attr-4": "value4"},
+        )
+        fs._call.assert_called_once_with(
+            fs._client.copy_object,
+            CopySource={"Bucket": "bucket", "Key": "key"},
+            Bucket="bucket",
+            Key="key",
+            Metadata={"attr1": "value1", "attr3": "value3", "attr-4": "value4"},
+            MetadataDirective="REPLACE",
+            ContentType="text/plain",
+        )
+
+    def test_setxattr_bucket_raises(self):
+        fs = self._make_fs()
+        with pytest.raises(ValueError, match="Cannot set metadata"):
+            fs.setxattr("s3://bucket", attr_1="value1")
+
+    def test_get_tags(self):
+        fs = self._make_fs()
+        fs._call.return_value = {"TagSet": [{"Key": "tag1", "Value": "value1"}]}
+
+        assert fs.get_tags("s3://bucket/key") == {"tag1": "value1"}
+        fs._call.assert_called_once_with(fs._client.get_object_tagging, Bucket="bucket", Key="key")
+
+    def test_put_tags_overwrite(self):
+        fs = self._make_fs()
+        fs.get_tags = mock.MagicMock(return_value={"tag1": "value1"})
+
+        fs.put_tags("s3://bucket/key", {"tag2": "value2"})
+        fs.get_tags.assert_not_called()
+        fs._call.assert_called_once_with(
+            fs._client.put_object_tagging,
+            Bucket="bucket",
+            Key="key",
+            Tagging={"TagSet": [{"Key": "tag2", "Value": "value2"}]},
+        )
+
+    def test_put_tags_merge(self):
+        fs = self._make_fs()
+        fs.get_tags = mock.MagicMock(return_value={"tag1": "value1"})
+
+        fs.put_tags("s3://bucket/key", {"tag2": "value2"}, mode="m")
+        fs._call.assert_called_once_with(
+            fs._client.put_object_tagging,
+            Bucket="bucket",
+            Key="key",
+            Tagging={
+                "TagSet": [
+                    {"Key": "tag1", "Value": "value1"},
+                    {"Key": "tag2", "Value": "value2"},
+                ]
+            },
+        )
+
+    def test_put_tags_invalid_mode_raises(self):
+        fs = self._make_fs()
+        with pytest.raises(ValueError, match="Mode must be"):
+            fs.put_tags("s3://bucket/key", {"tag1": "value1"}, mode="x")
+
+    def test_chmod_object(self):
+        fs = self._make_fs()
+
+        fs.chmod("s3://bucket/key", "bucket-owner-full-control")
+        fs._call.assert_called_once_with(
+            fs._client.put_object_acl,
+            Bucket="bucket",
+            Key="key",
+            ACL="bucket-owner-full-control",
+        )
+
+    def test_chmod_bucket(self):
+        fs = self._make_fs()
+
+        fs.chmod("s3://bucket", "private")
+        fs._call.assert_called_once_with(fs._client.put_bucket_acl, Bucket="bucket", ACL="private")
+
+    def test_chmod_invalid_acl_raises(self):
+        fs = self._make_fs()
+        with pytest.raises(ValueError, match="ACL not in"):
+            fs.chmod("s3://bucket/key", "invalid-acl")
+        with pytest.raises(ValueError, match="ACL not in"):
+            # A valid object ACL that is not valid for buckets.
+            fs.chmod("s3://bucket", "bucket-owner-full-control")
+        with pytest.raises(ValueError, match="ACL not in"):
+            # A recursive call must validate before applying any ACL.
+            fs.chmod("s3://bucket", "bucket-owner-full-control", recursive=True)
+        fs._call.assert_not_called()
+
+    def test_chmod_recursive(self):
+        fs = self._make_fs()
+        fs.find = mock.MagicMock(return_value=["bucket/key1", "bucket/key2"])
+
+        fs.chmod("s3://bucket/path", "private", recursive=True)
+        assert fs._call.call_count == 2
+        fs._call.assert_any_call(
+            fs._client.put_object_acl, Bucket="bucket", Key="key1", ACL="private"
+        )
+        fs._call.assert_any_call(
+            fs._client.put_object_acl, Bucket="bucket", Key="key2", ACL="private"
+        )
+
+    def test_list_multipart_uploads_paginates(self):
+        fs = self._make_fs()
+        fs._call.side_effect = [
+            {
+                "Uploads": [{"Key": "key1", "UploadId": "upload1"}],
+                "IsTruncated": True,
+                "NextKeyMarker": "key1",
+                "NextUploadIdMarker": "upload1",
+            },
+            {
+                "Uploads": [{"Key": "key2", "UploadId": "upload2"}],
+                "IsTruncated": False,
+            },
+        ]
+
+        actual = fs.list_multipart_uploads("s3://bucket")
+        assert [(u.bucket, u.key, u.upload_id) for u in actual] == [
+            ("bucket", "key1", "upload1"),
+            ("bucket", "key2", "upload2"),
+        ]
+        fs._call.assert_any_call(fs._client.list_multipart_uploads, Bucket="bucket")
+        fs._call.assert_any_call(
+            fs._client.list_multipart_uploads,
+            Bucket="bucket",
+            KeyMarker="key1",
+            UploadIdMarker="upload1",
+        )
+
+    def test_list_multipart_uploads_with_prefix(self):
+        fs = self._make_fs()
+        fs._call.return_value = {"Uploads": [], "IsTruncated": False}
+
+        assert fs.list_multipart_uploads("s3://bucket/path/to/prefix") == []
+        fs._call.assert_called_once_with(
+            fs._client.list_multipart_uploads, Bucket="bucket", Prefix="path/to/prefix"
+        )
+
+    def test_clear_multipart_uploads(self):
+        fs = self._make_fs()
+        fs.list_multipart_uploads = mock.MagicMock(
+            return_value=[
+                SimpleNamespace(key="key1", upload_id="upload1"),
+                SimpleNamespace(key="key2", upload_id="upload2"),
+            ]
+        )
+
+        fs.clear_multipart_uploads("bucket")
+        assert fs._call.call_count == 2
+        fs._call.assert_any_call(
+            fs._client.abort_multipart_upload, Bucket="bucket", Key="key1", UploadId="upload1"
+        )
+        fs._call.assert_any_call(
+            fs._client.abort_multipart_upload, Bucket="bucket", Key="key2", UploadId="upload2"
+        )
+
     @pytest.fixture(scope="class")
     def fs(self, request):
         if not hasattr(request, "param"):
@@ -989,341 +1321,6 @@ class TestS3FileSystem:
 
             actual = pandas.read_csv(path)
             pandas.testing.assert_frame_equal(actual, df)
-
-
-class TestS3FileSystemMocked:
-    """Unit tests for S3FileSystem methods with a mocked client (no AWS access)."""
-
-    @staticmethod
-    def _make_fs():
-        # Build a minimal S3FileSystem without touching AWS, bypassing
-        # __init__ which would require a boto3 client.
-        fs = S3FileSystem.__new__(S3FileSystem)
-        fs.dircache = {}
-        fs._client = mock.MagicMock()
-        fs._call = mock.MagicMock()
-        fs._retry_config = RetryConfig()
-        fs.request_kwargs = {}
-        return fs
-
-    def test_call_translates_client_error(self):
-        fs = self._make_fs()
-        del fs._call  # Use the real method instead of the mock.
-        func = mock.MagicMock(
-            side_effect=botocore.exceptions.ClientError(
-                {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}}, "HeadObject"
-            )
-        )
-        with pytest.raises(PermissionError, match="Access Denied"):
-            fs._call(func)
-
-    def test_ls_from_cache_with_cached_object(self):
-        fs = self._make_fs()
-        obj = S3Object(
-            init={
-                "ContentLength": 4,
-                "ContentType": None,
-                "StorageClass": S3StorageClass.S3_STORAGE_CLASS_STANDARD,
-                "ETag": '"etag"',
-                "LastModified": None,
-            },
-            type=S3ObjectType.S3_OBJECT_TYPE_FILE,
-            bucket="bucket",
-            key="key",
-        )
-        fs.dircache["bucket/key"] = obj
-
-        assert fs._ls_from_cache("bucket/key") is obj
-        # A child path of a cached object entry must not fail; it falls
-        # through to the S3 API instead (fsspec's implementation assumes
-        # every cache value is a listing and raises TypeError here).
-        assert fs._ls_from_cache("bucket/key/child") is None
-
-    def test_mkdir_creates_bucket(self):
-        fs = self._make_fs()
-        fs.exists = mock.MagicMock(return_value=False)
-        fs._client.meta.region_name = "ap-northeast-1"
-        fs.dircache[""] = ["stale-bucket-listing"]
-
-        fs.mkdir("s3://new-bucket")
-        fs._call.assert_called_once_with(
-            fs._client.create_bucket,
-            Bucket="new-bucket",
-            CreateBucketConfiguration={"LocationConstraint": "ap-northeast-1"},
-        )
-        # The cached bucket listing must be evicted.
-        assert "" not in fs.dircache
-
-    def test_mkdir_creates_bucket_in_us_east_1_without_location_constraint(self):
-        fs = self._make_fs()
-        fs.exists = mock.MagicMock(return_value=False)
-        fs._client.meta.region_name = "us-east-1"
-
-        fs.mkdir("s3://new-bucket")
-        fs._call.assert_called_once_with(fs._client.create_bucket, Bucket="new-bucket")
-
-    def test_mkdir_creates_bucket_with_acl(self):
-        fs = self._make_fs()
-        fs.exists = mock.MagicMock(return_value=False)
-        fs._client.meta.region_name = "us-east-1"
-
-        fs.mkdir("s3://new-bucket", acl="private")
-        fs._call.assert_called_once_with(
-            fs._client.create_bucket, Bucket="new-bucket", ACL="private"
-        )
-
-        with pytest.raises(ValueError, match="ACL not in"):
-            fs.mkdir("s3://another-bucket", acl="invalid-acl")
-
-    def test_mkdir_existing_bucket_raises(self):
-        fs = self._make_fs()
-        fs.exists = mock.MagicMock(return_value=True)
-
-        with pytest.raises(FileExistsError):
-            fs.mkdir("s3://bucket")
-        fs._call.assert_not_called()
-
-    def test_mkdir_key_under_existing_bucket_is_noop(self):
-        fs = self._make_fs()
-        fs.exists = mock.MagicMock(return_value=True)
-
-        fs.mkdir("s3://bucket/path/to/dir")
-        fs._call.assert_not_called()
-
-    def test_mkdir_key_without_create_parents_checks_bucket(self):
-        fs = self._make_fs()
-        fs.exists = mock.MagicMock(return_value=False)
-        fs.ls = mock.MagicMock(side_effect=FileNotFoundError("bucket"))
-
-        with pytest.raises(FileNotFoundError):
-            fs.mkdir("s3://bucket/path/to/dir", create_parents=False)
-        fs._call.assert_not_called()
-
-    def test_makedirs_exist_ok(self):
-        fs = self._make_fs()
-        fs.mkdir = mock.MagicMock(side_effect=FileExistsError("bucket"))
-
-        fs.makedirs("s3://bucket", exist_ok=True)
-        with pytest.raises(FileExistsError):
-            fs.makedirs("s3://bucket", exist_ok=False)
-
-    def test_rmdir_deletes_bucket(self):
-        fs = self._make_fs()
-        fs.dircache[""] = ["stale-bucket-listing"]
-
-        fs.rmdir("s3://bucket")
-        fs._call.assert_called_once_with(fs._client.delete_bucket, Bucket="bucket")
-        # The cached bucket listing must be evicted.
-        assert "" not in fs.dircache
-
-    def test_rmdir_key_raises(self):
-        fs = self._make_fs()
-        fs.exists = mock.MagicMock(return_value=True)
-        with pytest.raises(FileExistsError):
-            fs.rmdir("s3://bucket/existing-key")
-
-        fs.exists = mock.MagicMock(return_value=False)
-        with pytest.raises(FileNotFoundError):
-            fs.rmdir("s3://bucket/nonexistent-key")
-        fs._call.assert_not_called()
-
-    def test_metadata(self):
-        fs = self._make_fs()
-        fs._call.return_value = {"Metadata": {"foo_bar": "baz"}}
-
-        # The keys are returned as stored, without any transformation.
-        assert fs.metadata("s3://bucket/key") == {"foo_bar": "baz"}
-        fs._call.assert_called_once_with(fs._client.head_object, Bucket="bucket", Key="key")
-
-    def test_metadata_with_version_id(self):
-        fs = self._make_fs()
-        fs._call.return_value = {"Metadata": {}}
-
-        assert fs.metadata("s3://bucket/key?versionId=12345abcde") == {}
-        fs._call.assert_called_once_with(
-            fs._client.head_object, Bucket="bucket", Key="key", VersionId="12345abcde"
-        )
-
-    def test_metadata_bucket_raises(self):
-        fs = self._make_fs()
-        with pytest.raises(ValueError, match="Cannot get metadata"):
-            fs.metadata("s3://bucket")
-
-    def test_getxattr(self):
-        fs = self._make_fs()
-        fs.metadata = mock.MagicMock(return_value={"attr-1": "value1"})
-
-        # The attribute name is looked up as-is, without any transformation.
-        assert fs.getxattr("s3://bucket/key", "attr-1") == "value1"
-        assert fs.getxattr("s3://bucket/key", "attr_1") is None
-        assert fs.getxattr("s3://bucket/key", "missing") is None
-
-    def test_setxattr(self):
-        fs = self._make_fs()
-        fs.metadata = mock.MagicMock(return_value={"attr1": "value1", "attr2": "value2"})
-
-        # The keys are used as-is; hyphenated names can be passed by
-        # unpacking a dictionary.
-        fs.setxattr(
-            "s3://bucket/key",
-            copy_kwargs={"ContentType": "text/plain"},
-            attr2=None,
-            attr3="value3",
-            **{"attr-4": "value4"},
-        )
-        fs._call.assert_called_once_with(
-            fs._client.copy_object,
-            CopySource={"Bucket": "bucket", "Key": "key"},
-            Bucket="bucket",
-            Key="key",
-            Metadata={"attr1": "value1", "attr3": "value3", "attr-4": "value4"},
-            MetadataDirective="REPLACE",
-            ContentType="text/plain",
-        )
-
-    def test_setxattr_bucket_raises(self):
-        fs = self._make_fs()
-        with pytest.raises(ValueError, match="Cannot set metadata"):
-            fs.setxattr("s3://bucket", attr_1="value1")
-
-    def test_get_tags(self):
-        fs = self._make_fs()
-        fs._call.return_value = {"TagSet": [{"Key": "tag1", "Value": "value1"}]}
-
-        assert fs.get_tags("s3://bucket/key") == {"tag1": "value1"}
-        fs._call.assert_called_once_with(fs._client.get_object_tagging, Bucket="bucket", Key="key")
-
-    def test_put_tags_overwrite(self):
-        fs = self._make_fs()
-        fs.get_tags = mock.MagicMock(return_value={"tag1": "value1"})
-
-        fs.put_tags("s3://bucket/key", {"tag2": "value2"})
-        fs.get_tags.assert_not_called()
-        fs._call.assert_called_once_with(
-            fs._client.put_object_tagging,
-            Bucket="bucket",
-            Key="key",
-            Tagging={"TagSet": [{"Key": "tag2", "Value": "value2"}]},
-        )
-
-    def test_put_tags_merge(self):
-        fs = self._make_fs()
-        fs.get_tags = mock.MagicMock(return_value={"tag1": "value1"})
-
-        fs.put_tags("s3://bucket/key", {"tag2": "value2"}, mode="m")
-        fs._call.assert_called_once_with(
-            fs._client.put_object_tagging,
-            Bucket="bucket",
-            Key="key",
-            Tagging={
-                "TagSet": [
-                    {"Key": "tag1", "Value": "value1"},
-                    {"Key": "tag2", "Value": "value2"},
-                ]
-            },
-        )
-
-    def test_put_tags_invalid_mode_raises(self):
-        fs = self._make_fs()
-        with pytest.raises(ValueError, match="Mode must be"):
-            fs.put_tags("s3://bucket/key", {"tag1": "value1"}, mode="x")
-
-    def test_chmod_object(self):
-        fs = self._make_fs()
-
-        fs.chmod("s3://bucket/key", "bucket-owner-full-control")
-        fs._call.assert_called_once_with(
-            fs._client.put_object_acl,
-            Bucket="bucket",
-            Key="key",
-            ACL="bucket-owner-full-control",
-        )
-
-    def test_chmod_bucket(self):
-        fs = self._make_fs()
-
-        fs.chmod("s3://bucket", "private")
-        fs._call.assert_called_once_with(fs._client.put_bucket_acl, Bucket="bucket", ACL="private")
-
-    def test_chmod_invalid_acl_raises(self):
-        fs = self._make_fs()
-        with pytest.raises(ValueError, match="ACL not in"):
-            fs.chmod("s3://bucket/key", "invalid-acl")
-        with pytest.raises(ValueError, match="ACL not in"):
-            # A valid object ACL that is not valid for buckets.
-            fs.chmod("s3://bucket", "bucket-owner-full-control")
-        with pytest.raises(ValueError, match="ACL not in"):
-            # A recursive call must validate before applying any ACL.
-            fs.chmod("s3://bucket", "bucket-owner-full-control", recursive=True)
-        fs._call.assert_not_called()
-
-    def test_chmod_recursive(self):
-        fs = self._make_fs()
-        fs.find = mock.MagicMock(return_value=["bucket/key1", "bucket/key2"])
-
-        fs.chmod("s3://bucket/path", "private", recursive=True)
-        assert fs._call.call_count == 2
-        fs._call.assert_any_call(
-            fs._client.put_object_acl, Bucket="bucket", Key="key1", ACL="private"
-        )
-        fs._call.assert_any_call(
-            fs._client.put_object_acl, Bucket="bucket", Key="key2", ACL="private"
-        )
-
-    def test_list_multipart_uploads_paginates(self):
-        fs = self._make_fs()
-        fs._call.side_effect = [
-            {
-                "Uploads": [{"Key": "key1", "UploadId": "upload1"}],
-                "IsTruncated": True,
-                "NextKeyMarker": "key1",
-                "NextUploadIdMarker": "upload1",
-            },
-            {
-                "Uploads": [{"Key": "key2", "UploadId": "upload2"}],
-                "IsTruncated": False,
-            },
-        ]
-
-        actual = fs.list_multipart_uploads("s3://bucket")
-        assert [(u.bucket, u.key, u.upload_id) for u in actual] == [
-            ("bucket", "key1", "upload1"),
-            ("bucket", "key2", "upload2"),
-        ]
-        fs._call.assert_any_call(fs._client.list_multipart_uploads, Bucket="bucket")
-        fs._call.assert_any_call(
-            fs._client.list_multipart_uploads,
-            Bucket="bucket",
-            KeyMarker="key1",
-            UploadIdMarker="upload1",
-        )
-
-    def test_list_multipart_uploads_with_prefix(self):
-        fs = self._make_fs()
-        fs._call.return_value = {"Uploads": [], "IsTruncated": False}
-
-        assert fs.list_multipart_uploads("s3://bucket/path/to/prefix") == []
-        fs._call.assert_called_once_with(
-            fs._client.list_multipart_uploads, Bucket="bucket", Prefix="path/to/prefix"
-        )
-
-    def test_clear_multipart_uploads(self):
-        fs = self._make_fs()
-        fs.list_multipart_uploads = mock.MagicMock(
-            return_value=[
-                SimpleNamespace(key="key1", upload_id="upload1"),
-                SimpleNamespace(key="key2", upload_id="upload2"),
-            ]
-        )
-
-        fs.clear_multipart_uploads("bucket")
-        assert fs._call.call_count == 2
-        fs._call.assert_any_call(
-            fs._client.abort_multipart_upload, Bucket="bucket", Key="key1", UploadId="upload1"
-        )
-        fs._call.assert_any_call(
-            fs._client.abort_multipart_upload, Bucket="bucket", Key="key2", UploadId="upload2"
-        )
 
 
 class TestS3File:

--- a/tests/pyathena/filesystem/test_s3.py
+++ b/tests/pyathena/filesystem/test_s3.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
-import botocore.exceptions
 import fsspec
 import pytest
 from fsspec import Callback
@@ -141,18 +140,9 @@ class TestS3FileSystem:
         fs._retry_config = RetryConfig()
         fs.request_kwargs = {}
         fs.max_workers = 4
+        fs.allow_bucket_creation = False
+        fs.allow_bucket_deletion = False
         return fs
-
-    def test_call_translates_client_error(self):
-        fs = self._make_fs()
-        del fs._call  # Use the real method instead of the mock.
-        func = mock.MagicMock(
-            side_effect=botocore.exceptions.ClientError(
-                {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}}, "HeadObject"
-            )
-        )
-        with pytest.raises(PermissionError, match="Access Denied"):
-            fs._call(func)
 
     def test_ls_from_cache_with_cached_object(self):
         fs = self._make_fs()
@@ -178,6 +168,7 @@ class TestS3FileSystem:
 
     def test_mkdir_creates_bucket(self):
         fs = self._make_fs()
+        fs.allow_bucket_creation = True
         fs.exists = mock.MagicMock(return_value=False)
         fs._client.meta.region_name = "ap-northeast-1"
         fs.dircache[""] = ["stale-bucket-listing"]
@@ -193,6 +184,7 @@ class TestS3FileSystem:
 
     def test_mkdir_creates_bucket_in_us_east_1_without_location_constraint(self):
         fs = self._make_fs()
+        fs.allow_bucket_creation = True
         fs.exists = mock.MagicMock(return_value=False)
         fs._client.meta.region_name = "us-east-1"
 
@@ -201,6 +193,7 @@ class TestS3FileSystem:
 
     def test_mkdir_creates_bucket_with_acl(self):
         fs = self._make_fs()
+        fs.allow_bucket_creation = True
         fs.exists = mock.MagicMock(return_value=False)
         fs._client.meta.region_name = "us-east-1"
 
@@ -212,39 +205,18 @@ class TestS3FileSystem:
         with pytest.raises(ValueError, match="ACL not in"):
             fs.mkdir("s3://another-bucket", acl="invalid-acl")
 
-    def test_mkdir_existing_bucket_raises(self):
-        fs = self._make_fs()
-        fs.exists = mock.MagicMock(return_value=True)
-
-        with pytest.raises(FileExistsError):
-            fs.mkdir("s3://bucket")
-        fs._call.assert_not_called()
-
-    def test_mkdir_key_under_existing_bucket_is_noop(self):
-        fs = self._make_fs()
-        fs.exists = mock.MagicMock(return_value=True)
-
-        fs.mkdir("s3://bucket/path/to/dir")
-        fs._call.assert_not_called()
-
-    def test_mkdir_key_without_create_parents_raises(self):
+    def test_mkdir_bucket_creation_disabled(self):
+        # Bucket creation is disabled by default.
         fs = self._make_fs()
         fs.exists = mock.MagicMock(return_value=False)
 
-        with pytest.raises(FileNotFoundError):
-            fs.mkdir("s3://bucket/path/to/dir", create_parents=False)
+        with pytest.raises(PermissionError, match="Bucket creation is disabled"):
+            fs.mkdir("s3://new-bucket")
         fs._call.assert_not_called()
-
-    def test_makedirs_exist_ok(self):
-        fs = self._make_fs()
-        fs.mkdir = mock.MagicMock(side_effect=FileExistsError("bucket"))
-
-        fs.makedirs("s3://bucket", exist_ok=True)
-        with pytest.raises(FileExistsError):
-            fs.makedirs("s3://bucket", exist_ok=False)
 
     def test_rmdir_deletes_bucket(self):
         fs = self._make_fs()
+        fs.allow_bucket_deletion = True
         fs.dircache[""] = ["stale-bucket-listing"]
 
         fs.rmdir("s3://bucket")
@@ -252,24 +224,13 @@ class TestS3FileSystem:
         # The cached bucket listing must be evicted.
         assert "" not in fs.dircache
 
-    def test_rmdir_key_raises(self):
+    def test_rmdir_bucket_deletion_disabled(self):
+        # Bucket deletion is disabled by default.
         fs = self._make_fs()
-        fs.exists = mock.MagicMock(return_value=True)
-        with pytest.raises(FileExistsError):
-            fs.rmdir("s3://bucket/existing-key")
 
-        fs.exists = mock.MagicMock(return_value=False)
-        with pytest.raises(FileNotFoundError):
-            fs.rmdir("s3://bucket/nonexistent-key")
+        with pytest.raises(PermissionError, match="Bucket deletion is disabled"):
+            fs.rmdir("s3://bucket")
         fs._call.assert_not_called()
-
-    def test_metadata(self):
-        fs = self._make_fs()
-        fs._call.return_value = {"Metadata": {"foo_bar": "baz"}}
-
-        # The keys are returned as stored, without any transformation.
-        assert fs.metadata("s3://bucket/key") == {"foo_bar": "baz"}
-        fs._call.assert_called_once_with(fs._client.head_object, Bucket="bucket", Key="key")
 
     def test_metadata_with_version_id(self):
         fs = self._make_fs()
@@ -279,90 +240,6 @@ class TestS3FileSystem:
         fs._call.assert_called_once_with(
             fs._client.head_object, Bucket="bucket", Key="key", VersionId="12345abcde"
         )
-
-    def test_metadata_bucket_raises(self):
-        fs = self._make_fs()
-        with pytest.raises(ValueError, match="Cannot get metadata"):
-            fs.metadata("s3://bucket")
-
-    def test_getxattr(self):
-        fs = self._make_fs()
-        fs.metadata = mock.MagicMock(return_value={"attr-1": "value1"})
-
-        # The attribute name is looked up as-is, without any transformation.
-        assert fs.getxattr("s3://bucket/key", "attr-1") == "value1"
-        assert fs.getxattr("s3://bucket/key", "attr_1") is None
-        assert fs.getxattr("s3://bucket/key", "missing") is None
-
-    def test_setxattr(self):
-        fs = self._make_fs()
-        fs.metadata = mock.MagicMock(return_value={"attr1": "value1", "attr2": "value2"})
-
-        # The keys are used as-is; hyphenated names can be passed by
-        # unpacking a dictionary.
-        fs.setxattr(
-            "s3://bucket/key",
-            copy_kwargs={"ContentType": "text/plain"},
-            attr2=None,
-            attr3="value3",
-            **{"attr-4": "value4"},
-        )
-        fs._call.assert_called_once_with(
-            fs._client.copy_object,
-            CopySource={"Bucket": "bucket", "Key": "key"},
-            Bucket="bucket",
-            Key="key",
-            Metadata={"attr1": "value1", "attr3": "value3", "attr-4": "value4"},
-            MetadataDirective="REPLACE",
-            ContentType="text/plain",
-        )
-
-    def test_setxattr_bucket_raises(self):
-        fs = self._make_fs()
-        with pytest.raises(ValueError, match="Cannot set metadata"):
-            fs.setxattr("s3://bucket", attr_1="value1")
-
-    def test_get_tags(self):
-        fs = self._make_fs()
-        fs._call.return_value = {"TagSet": [{"Key": "tag1", "Value": "value1"}]}
-
-        assert fs.get_tags("s3://bucket/key") == {"tag1": "value1"}
-        fs._call.assert_called_once_with(fs._client.get_object_tagging, Bucket="bucket", Key="key")
-
-    def test_put_tags_overwrite(self):
-        fs = self._make_fs()
-        fs.get_tags = mock.MagicMock(return_value={"tag1": "value1"})
-
-        fs.put_tags("s3://bucket/key", {"tag2": "value2"})
-        fs.get_tags.assert_not_called()
-        fs._call.assert_called_once_with(
-            fs._client.put_object_tagging,
-            Bucket="bucket",
-            Key="key",
-            Tagging={"TagSet": [{"Key": "tag2", "Value": "value2"}]},
-        )
-
-    def test_put_tags_merge(self):
-        fs = self._make_fs()
-        fs.get_tags = mock.MagicMock(return_value={"tag1": "value1"})
-
-        fs.put_tags("s3://bucket/key", {"tag2": "value2"}, mode="m")
-        fs._call.assert_called_once_with(
-            fs._client.put_object_tagging,
-            Bucket="bucket",
-            Key="key",
-            Tagging={
-                "TagSet": [
-                    {"Key": "tag1", "Value": "value1"},
-                    {"Key": "tag2", "Value": "value2"},
-                ]
-            },
-        )
-
-    def test_put_tags_invalid_mode_raises(self):
-        fs = self._make_fs()
-        with pytest.raises(ValueError, match="Mode must be"):
-            fs.put_tags("s3://bucket/key", {"tag1": "value1"}, mode="x")
 
     def test_chmod_object(self):
         fs = self._make_fs()
@@ -380,18 +257,6 @@ class TestS3FileSystem:
 
         fs.chmod("s3://bucket", "private")
         fs._call.assert_called_once_with(fs._client.put_bucket_acl, Bucket="bucket", ACL="private")
-
-    def test_chmod_invalid_acl_raises(self):
-        fs = self._make_fs()
-        with pytest.raises(ValueError, match="ACL not in"):
-            fs.chmod("s3://bucket/key", "invalid-acl")
-        with pytest.raises(ValueError, match="ACL not in"):
-            # A valid object ACL that is not valid for buckets.
-            fs.chmod("s3://bucket", "bucket-owner-full-control")
-        with pytest.raises(ValueError, match="ACL not in"):
-            # A recursive call must validate before applying any ACL.
-            fs.chmod("s3://bucket", "bucket-owner-full-control", recursive=True)
-        fs._call.assert_not_called()
 
     def test_chmod_recursive(self):
         fs = self._make_fs()
@@ -432,33 +297,6 @@ class TestS3FileSystem:
             Bucket="bucket",
             KeyMarker="key1",
             UploadIdMarker="upload1",
-        )
-
-    def test_list_multipart_uploads_with_prefix(self):
-        fs = self._make_fs()
-        fs._call.return_value = {"Uploads": [], "IsTruncated": False}
-
-        assert fs.list_multipart_uploads("s3://bucket/path/to/prefix") == []
-        fs._call.assert_called_once_with(
-            fs._client.list_multipart_uploads, Bucket="bucket", Prefix="path/to/prefix"
-        )
-
-    def test_clear_multipart_uploads(self):
-        fs = self._make_fs()
-        fs.list_multipart_uploads = mock.MagicMock(
-            return_value=[
-                SimpleNamespace(bucket="bucket", key="key1", upload_id="upload1"),
-                SimpleNamespace(bucket="bucket", key="key2", upload_id="upload2"),
-            ]
-        )
-
-        fs.clear_multipart_uploads("bucket")
-        assert fs._call.call_count == 2
-        fs._call.assert_any_call(
-            fs._client.abort_multipart_upload, Bucket="bucket", Key="key1", UploadId="upload1"
-        )
-        fs._call.assert_any_call(
-            fs._client.abort_multipart_upload, Bucket="bucket", Key="key2", UploadId="upload2"
         )
 
     @pytest.fixture(scope="class")
@@ -1162,7 +1000,7 @@ class TestS3FileSystem:
         assert data == b"0123456789"
 
     def test_mkdir_and_rmdir(self, fs):
-        # The bucket already exists.
+        # The bucket already exists; raised regardless of the flags.
         with pytest.raises(FileExistsError):
             fs.mkdir(f"s3://{ENV.s3_staging_bucket}")
         # exist_ok suppresses the error.
@@ -1174,6 +1012,16 @@ class TestS3FileSystem:
             f"s3://{ENV.s3_staging_bucket}/{ENV.s3_staging_key}{ENV.schema}/"
             f"filesystem/test_mkdir/{uuid.uuid4()}"
         )
+
+        # Bucket creation/deletion are disabled by default.
+        nonexistent = f"s3://pyathena-test-{uuid.uuid4()}"
+        with pytest.raises(PermissionError, match="Bucket creation is disabled"):
+            fs.mkdir(nonexistent)
+        with pytest.raises(PermissionError, match="Bucket deletion is disabled"):
+            fs.rmdir(f"s3://{ENV.s3_staging_bucket}")
+        # The bucket does not exist, and it is not requested to be created.
+        with pytest.raises(FileNotFoundError):
+            fs.mkdir(f"{nonexistent}/dir", create_parents=False)
 
         path = (
             f"s3://{ENV.s3_staging_bucket}/{ENV.s3_staging_key}{ENV.schema}/"
@@ -1208,11 +1056,21 @@ class TestS3FileSystem:
         assert fs.metadata(path) == {"attr1": "value1", "attr3": "value3"}
         assert fs.cat(path) == data
 
+        # copy_kwargs are passed to the underlying CopyObject API.
+        fs.setxattr(path, copy_kwargs={"ContentType": "text/plain"}, attr4="value4")
+        info = fs.info(path, refresh=True)
+        assert info.get("content_type") == "text/plain"
+        assert fs.getxattr(path, "attr4") == "value4"
+
         with pytest.raises(FileNotFoundError):
             fs.metadata(
                 f"s3://{ENV.s3_staging_bucket}/{ENV.s3_staging_key}{ENV.schema}/"
                 f"filesystem/test_metadata/nonexistent-{uuid.uuid4()}"
             )
+        with pytest.raises(ValueError, match="Cannot get metadata"):
+            fs.metadata(f"s3://{ENV.s3_staging_bucket}")
+        with pytest.raises(ValueError, match="Cannot set metadata"):
+            fs.setxattr(f"s3://{ENV.s3_staging_bucket}", attr1="value1")
 
     def test_get_and_put_tags(self, fs):
         path = (
@@ -1232,6 +1090,27 @@ class TestS3FileSystem:
         # Overwrite mode replaces the existing tags.
         fs.put_tags(path, {"tag3": "value3"}, mode="o")
         assert fs.get_tags(path) == {"tag3": "value3"}
+
+        with pytest.raises(ValueError, match="Mode must be"):
+            fs.put_tags(path, {"tag4": "value4"}, mode="x")
+
+    def test_chmod_validation(self, fs):
+        # Canned ACLs are validated before any API call; applying ACLs is
+        # not integration-tested because the test bucket has ACLs disabled.
+        with pytest.raises(ValueError, match="ACL not in"):
+            fs.chmod(f"s3://{ENV.s3_staging_bucket}/key", "invalid-acl")
+        with pytest.raises(ValueError, match="ACL not in"):
+            # A valid object ACL that is not valid for buckets.
+            fs.chmod(f"s3://{ENV.s3_staging_bucket}", "bucket-owner-full-control")
+        with pytest.raises(ValueError, match="ACL not in"):
+            # A recursive call must validate before applying any ACL.
+            fs.chmod(f"s3://{ENV.s3_staging_bucket}", "bucket-owner-full-control", recursive=True)
+
+    def test_error_translation_permission_error(self):
+        # Unsigned access to a private object: 403 -> PermissionError.
+        anon_fs = S3FileSystem(anon=True, skip_instance_cache=True)
+        with pytest.raises(PermissionError):
+            anon_fs.info(f"s3://{ENV.s3_staging_bucket}/{ENV.s3_filesystem_test_file_key}")
 
     def test_list_and_clear_multipart_uploads(self, fs):
         # Scope the list/clear to a unique prefix so that parallel test
@@ -1477,43 +1356,3 @@ class TestS3File:
             file.commit()
         file.fs._complete_multipart_upload.assert_called_once()
         file.fs._put_object.assert_not_called()
-
-    def test_url_delegates_to_sign(self):
-        file = self._make_write_file(b"", autocommit=True)
-        file.fs.sign.return_value = "https://signed-url"
-
-        assert file.url(expiration=100) == "https://signed-url"
-        file.fs.sign.assert_called_once_with("s3://bucket/key.txt", expiration=100)
-
-    def test_metadata_and_getxattr_delegate_to_fs(self):
-        file = self._make_write_file(b"", autocommit=True)
-        file.fs.metadata.return_value = {"attr1": "value1"}
-        file.fs.getxattr.return_value = "value1"
-
-        assert file.metadata() == {"attr1": "value1"}
-        file.fs.metadata.assert_called_once_with("s3://bucket/key.txt")
-        assert file.getxattr("attr1") == "value1"
-        file.fs.getxattr.assert_called_once_with("s3://bucket/key.txt", "attr1")
-
-    def test_setxattr_write_mode_raises(self):
-        file = self._make_write_file(b"", autocommit=True)
-        file.mode = "wb"
-        file._closed = False
-
-        with pytest.raises(NotImplementedError):
-            file.setxattr(attr1="value1")
-        file.fs.setxattr.assert_not_called()
-        # Neutralize __del__, which would otherwise try to flush the
-        # partially-constructed file.
-        file._closed = True
-
-    def test_setxattr_read_mode_delegates_to_fs(self):
-        file = self._make_write_file(b"", autocommit=True)
-        file.mode = "rb"
-        file._closed = False
-
-        file.setxattr(copy_kwargs={"ContentType": "text/plain"}, attr1="value1")
-        file.fs.setxattr.assert_called_once_with(
-            "s3://bucket/key.txt", copy_kwargs={"ContentType": "text/plain"}, attr1="value1"
-        )
-        file._closed = True

--- a/tests/pyathena/filesystem/test_s3.py
+++ b/tests/pyathena/filesystem/test_s3.py
@@ -1056,10 +1056,16 @@ class TestS3FileSystem:
         assert fs.metadata(path) == {"attr1": "value1", "attr3": "value3"}
         assert fs.cat(path) == data
 
-        # copy_kwargs are passed to the underlying CopyObject API.
+        # copy_kwargs are passed to the underlying CopyObject API. The system
+        # metadata is exposed as typed properties on the returned S3Metadata,
+        # and the user-defined metadata through its mapping interface.
         fs.setxattr(path, copy_kwargs={"ContentType": "text/plain"}, attr4="value4")
-        info = fs.info(path, refresh=True)
-        assert info.get("content_type") == "text/plain"
+        metadata = fs.metadata(path)
+        assert metadata.content_type == "text/plain"
+        assert metadata["attr4"] == "value4"
+        assert metadata.user_metadata == {"attr1": "value1", "attr3": "value3", "attr4": "value4"}
+        assert metadata.content_length == len(data)
+        assert metadata.etag
         assert fs.getxattr(path, "attr4") == "value4"
 
         with pytest.raises(FileNotFoundError):

--- a/tests/pyathena/filesystem/test_s3.py
+++ b/tests/pyathena/filesystem/test_s3.py
@@ -864,14 +864,17 @@ class TestS3FileSystem:
         fs.pipe(path, data)
         assert fs.metadata(path) == {}
 
-        fs.setxattr(path, attr_1="value1", attr_2="value2")
-        assert fs.metadata(path) == {"attr-1": "value1", "attr-2": "value2"}
-        assert fs.getxattr(path, "attr_1") == "value1"
+        # The keys are stored as-is; hyphenated names can be passed by
+        # unpacking a dictionary.
+        fs.setxattr(path, attr1="value1", **{"attr-2": "value2"})
+        assert fs.metadata(path) == {"attr1": "value1", "attr-2": "value2"}
+        assert fs.getxattr(path, "attr1") == "value1"
+        assert fs.getxattr(path, "attr-2") == "value2"
         assert fs.getxattr(path, "missing") is None
 
         # Setting a field to None deletes it, and the content is preserved.
-        fs.setxattr(path, attr_2=None, attr_3="value3")
-        assert fs.metadata(path) == {"attr-1": "value1", "attr-3": "value3"}
+        fs.setxattr(path, attr3="value3", **{"attr-2": None})
+        assert fs.metadata(path) == {"attr1": "value1", "attr3": "value3"}
         assert fs.cat(path) == data
 
         with pytest.raises(FileNotFoundError):
@@ -900,19 +903,26 @@ class TestS3FileSystem:
         assert fs.get_tags(path) == {"tag3": "value3"}
 
     def test_list_and_clear_multipart_uploads(self, fs):
+        # Scope the list/clear to a unique prefix so that parallel test
+        # workers' in-flight multipart uploads in the shared bucket are
+        # not aborted.
         bucket = ENV.s3_staging_bucket
-        key = f"{ENV.s3_staging_key}{ENV.schema}/filesystem/test_multipart_uploads/{uuid.uuid4()}"
+        prefix = (
+            f"{ENV.s3_staging_key}{ENV.schema}/filesystem/test_multipart_uploads/{uuid.uuid4()}"
+        )
+        prefix_path = f"s3://{bucket}/{prefix}"
+        key = f"{prefix}/file"
         upload = fs._create_multipart_upload(bucket=bucket, key=key)
 
-        uploads = fs.list_multipart_uploads(bucket)
+        uploads = fs.list_multipart_uploads(prefix_path)
         listed = next((u for u in uploads if u.upload_id == upload.upload_id), None)
         assert listed
         assert listed.bucket == bucket
         assert listed.key == key
         assert listed.initiated
 
-        fs.clear_multipart_uploads(bucket)
-        uploads = fs.list_multipart_uploads(f"s3://{bucket}")
+        fs.clear_multipart_uploads(prefix_path)
+        uploads = fs.list_multipart_uploads(prefix_path)
         assert not any(u.upload_id == upload.upload_id for u in uploads)
 
     def test_file_url_metadata_getxattr_setxattr(self, fs):
@@ -922,18 +932,18 @@ class TestS3FileSystem:
         )
         data = b"0123456789"
         fs.pipe(path, data)
-        fs.setxattr(path, attr_1="value1")
+        fs.setxattr(path, attr1="value1")
 
         with fs.open(path, "rb") as f:
-            assert f.metadata() == {"attr-1": "value1"}
-            assert f.getxattr("attr_1") == "value1"
+            assert f.metadata() == {"attr1": "value1"}
+            assert f.getxattr("attr1") == "value1"
             url = f.url(expiration=100)
             with urllib.request.urlopen(url) as r:
                 assert r.read() == data
 
         with fs.open(path, "wb") as f:
             with pytest.raises(NotImplementedError):
-                f.setxattr(attr_2="value2")
+                f.setxattr(attr2="value2")
             f.write(data)
 
     def test_pandas_read_csv(self):
@@ -1033,6 +1043,7 @@ class TestS3FileSystemMocked:
         fs = self._make_fs()
         fs.exists = mock.MagicMock(return_value=False)
         fs._client.meta.region_name = "ap-northeast-1"
+        fs.dircache[""] = ["stale-bucket-listing"]
 
         fs.mkdir("s3://new-bucket")
         fs._call.assert_called_once_with(
@@ -1040,6 +1051,8 @@ class TestS3FileSystemMocked:
             Bucket="new-bucket",
             CreateBucketConfiguration={"LocationConstraint": "ap-northeast-1"},
         )
+        # The cached bucket listing must be evicted.
+        assert "" not in fs.dircache
 
     def test_mkdir_creates_bucket_in_us_east_1_without_location_constraint(self):
         fs = self._make_fs()
@@ -1096,9 +1109,12 @@ class TestS3FileSystemMocked:
 
     def test_rmdir_deletes_bucket(self):
         fs = self._make_fs()
+        fs.dircache[""] = ["stale-bucket-listing"]
 
         fs.rmdir("s3://bucket")
         fs._call.assert_called_once_with(fs._client.delete_bucket, Bucket="bucket")
+        # The cached bucket listing must be evicted.
+        assert "" not in fs.dircache
 
     def test_rmdir_key_raises(self):
         fs = self._make_fs()
@@ -1115,7 +1131,8 @@ class TestS3FileSystemMocked:
         fs = self._make_fs()
         fs._call.return_value = {"Metadata": {"foo_bar": "baz"}}
 
-        assert fs.metadata("s3://bucket/key") == {"foo-bar": "baz"}
+        # The keys are returned as stored, without any transformation.
+        assert fs.metadata("s3://bucket/key") == {"foo_bar": "baz"}
         fs._call.assert_called_once_with(fs._client.head_object, Bucket="bucket", Key="key")
 
     def test_metadata_with_version_id(self):
@@ -1136,26 +1153,30 @@ class TestS3FileSystemMocked:
         fs = self._make_fs()
         fs.metadata = mock.MagicMock(return_value={"attr-1": "value1"})
 
-        assert fs.getxattr("s3://bucket/key", "attr_1") == "value1"
+        # The attribute name is looked up as-is, without any transformation.
         assert fs.getxattr("s3://bucket/key", "attr-1") == "value1"
+        assert fs.getxattr("s3://bucket/key", "attr_1") is None
         assert fs.getxattr("s3://bucket/key", "missing") is None
 
     def test_setxattr(self):
         fs = self._make_fs()
-        fs.metadata = mock.MagicMock(return_value={"attr-1": "value1", "attr-2": "value2"})
+        fs.metadata = mock.MagicMock(return_value={"attr1": "value1", "attr2": "value2"})
 
+        # The keys are used as-is; hyphenated names can be passed by
+        # unpacking a dictionary.
         fs.setxattr(
             "s3://bucket/key",
             copy_kwargs={"ContentType": "text/plain"},
-            attr_2=None,
-            attr_3="value3",
+            attr2=None,
+            attr3="value3",
+            **{"attr-4": "value4"},
         )
         fs._call.assert_called_once_with(
             fs._client.copy_object,
             CopySource={"Bucket": "bucket", "Key": "key"},
             Bucket="bucket",
             Key="key",
-            Metadata={"attr-1": "value1", "attr-3": "value3"},
+            Metadata={"attr1": "value1", "attr3": "value3", "attr-4": "value4"},
             MetadataDirective="REPLACE",
             ContentType="text/plain",
         )
@@ -1231,6 +1252,9 @@ class TestS3FileSystemMocked:
         with pytest.raises(ValueError, match="ACL not in"):
             # A valid object ACL that is not valid for buckets.
             fs.chmod("s3://bucket", "bucket-owner-full-control")
+        with pytest.raises(ValueError, match="ACL not in"):
+            # A recursive call must validate before applying any ACL.
+            fs.chmod("s3://bucket", "bucket-owner-full-control", recursive=True)
         fs._call.assert_not_called()
 
     def test_chmod_recursive(self):
@@ -1272,6 +1296,15 @@ class TestS3FileSystemMocked:
             Bucket="bucket",
             KeyMarker="key1",
             UploadIdMarker="upload1",
+        )
+
+    def test_list_multipart_uploads_with_prefix(self):
+        fs = self._make_fs()
+        fs._call.return_value = {"Uploads": [], "IsTruncated": False}
+
+        assert fs.list_multipart_uploads("s3://bucket/path/to/prefix") == []
+        fs._call.assert_called_once_with(
+            fs._client.list_multipart_uploads, Bucket="bucket", Prefix="path/to/prefix"
         )
 
     def test_clear_multipart_uploads(self):
@@ -1458,13 +1491,13 @@ class TestS3File:
 
     def test_metadata_and_getxattr_delegate_to_fs(self):
         file = self._make_write_file(b"", autocommit=True)
-        file.fs.metadata.return_value = {"attr-1": "value1"}
+        file.fs.metadata.return_value = {"attr1": "value1"}
         file.fs.getxattr.return_value = "value1"
 
-        assert file.metadata() == {"attr-1": "value1"}
+        assert file.metadata() == {"attr1": "value1"}
         file.fs.metadata.assert_called_once_with("s3://bucket/key.txt")
-        assert file.getxattr("attr_1") == "value1"
-        file.fs.getxattr.assert_called_once_with("s3://bucket/key.txt", "attr_1")
+        assert file.getxattr("attr1") == "value1"
+        file.fs.getxattr.assert_called_once_with("s3://bucket/key.txt", "attr1")
 
     def test_setxattr_write_mode_raises(self):
         file = self._make_write_file(b"", autocommit=True)
@@ -1472,7 +1505,7 @@ class TestS3File:
         file._closed = False
 
         with pytest.raises(NotImplementedError):
-            file.setxattr(attr_1="value1")
+            file.setxattr(attr1="value1")
         file.fs.setxattr.assert_not_called()
         # Neutralize __del__, which would otherwise try to flush the
         # partially-constructed file.
@@ -1483,8 +1516,8 @@ class TestS3File:
         file.mode = "rb"
         file._closed = False
 
-        file.setxattr(copy_kwargs={"ContentType": "text/plain"}, attr_1="value1")
+        file.setxattr(copy_kwargs={"ContentType": "text/plain"}, attr1="value1")
         file.fs.setxattr.assert_called_once_with(
-            "s3://bucket/key.txt", copy_kwargs={"ContentType": "text/plain"}, attr_1="value1"
+            "s3://bucket/key.txt", copy_kwargs={"ContentType": "text/plain"}, attr1="value1"
         )
         file._closed = True

--- a/tests/pyathena/filesystem/test_s3.py
+++ b/tests/pyathena/filesystem/test_s3.py
@@ -227,10 +227,9 @@ class TestS3FileSystem:
         fs.mkdir("s3://bucket/path/to/dir")
         fs._call.assert_not_called()
 
-    def test_mkdir_key_without_create_parents_checks_bucket(self):
+    def test_mkdir_key_without_create_parents_raises(self):
         fs = self._make_fs()
         fs.exists = mock.MagicMock(return_value=False)
-        fs.ls = mock.MagicMock(side_effect=FileNotFoundError("bucket"))
 
         with pytest.raises(FileNotFoundError):
             fs.mkdir("s3://bucket/path/to/dir", create_parents=False)
@@ -448,8 +447,8 @@ class TestS3FileSystem:
         fs = self._make_fs()
         fs.list_multipart_uploads = mock.MagicMock(
             return_value=[
-                SimpleNamespace(key="key1", upload_id="upload1"),
-                SimpleNamespace(key="key2", upload_id="upload2"),
+                SimpleNamespace(bucket="bucket", key="key1", upload_id="upload1"),
+                SimpleNamespace(bucket="bucket", key="key2", upload_id="upload2"),
             ]
         )
 

--- a/tests/pyathena/filesystem/test_s3.py
+++ b/tests/pyathena/filesystem/test_s3.py
@@ -12,12 +12,14 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
+import botocore.exceptions
 import fsspec
 import pytest
 from fsspec import Callback
 
 from pyathena.filesystem.s3 import S3File, S3FileSystem
-from pyathena.filesystem.s3_object import S3ObjectType, S3StorageClass
+from pyathena.filesystem.s3_object import S3Object, S3ObjectType, S3StorageClass
+from pyathena.util import RetryConfig
 from tests import ENV
 from tests.pyathena.conftest import connect
 
@@ -828,6 +830,112 @@ class TestS3FileSystem:
         assert requested + 100 < expires
         assert data == b"0123456789"
 
+    def test_mkdir_and_rmdir(self, fs):
+        # The bucket already exists.
+        with pytest.raises(FileExistsError):
+            fs.mkdir(f"s3://{ENV.s3_staging_bucket}")
+        # exist_ok suppresses the error.
+        fs.makedirs(f"s3://{ENV.s3_staging_bucket}", exist_ok=True)
+        with pytest.raises(FileExistsError):
+            fs.makedirs(f"s3://{ENV.s3_staging_bucket}", exist_ok=False)
+        # Creating a key prefix under an existing bucket requires no operation.
+        fs.mkdir(
+            f"s3://{ENV.s3_staging_bucket}/{ENV.s3_staging_key}{ENV.schema}/"
+            f"filesystem/test_mkdir/{uuid.uuid4()}"
+        )
+
+        path = (
+            f"s3://{ENV.s3_staging_bucket}/{ENV.s3_staging_key}{ENV.schema}/"
+            f"filesystem/test_rmdir/{uuid.uuid4()}"
+        )
+        fs.pipe(path, b"data")
+        # Only bucket paths can be removed.
+        with pytest.raises(FileExistsError):
+            fs.rmdir(path)
+        with pytest.raises(FileNotFoundError):
+            fs.rmdir(f"{path}/nonexistent")
+
+    def test_metadata_getxattr_setxattr(self, fs):
+        path = (
+            f"s3://{ENV.s3_staging_bucket}/{ENV.s3_staging_key}{ENV.schema}/"
+            f"filesystem/test_metadata/{uuid.uuid4()}"
+        )
+        data = b"0123456789"
+        fs.pipe(path, data)
+        assert fs.metadata(path) == {}
+
+        fs.setxattr(path, attr_1="value1", attr_2="value2")
+        assert fs.metadata(path) == {"attr-1": "value1", "attr-2": "value2"}
+        assert fs.getxattr(path, "attr_1") == "value1"
+        assert fs.getxattr(path, "missing") is None
+
+        # Setting a field to None deletes it, and the content is preserved.
+        fs.setxattr(path, attr_2=None, attr_3="value3")
+        assert fs.metadata(path) == {"attr-1": "value1", "attr-3": "value3"}
+        assert fs.cat(path) == data
+
+        with pytest.raises(FileNotFoundError):
+            fs.metadata(
+                f"s3://{ENV.s3_staging_bucket}/{ENV.s3_staging_key}{ENV.schema}/"
+                f"filesystem/test_metadata/nonexistent-{uuid.uuid4()}"
+            )
+
+    def test_get_and_put_tags(self, fs):
+        path = (
+            f"s3://{ENV.s3_staging_bucket}/{ENV.s3_staging_key}{ENV.schema}/"
+            f"filesystem/test_tags/{uuid.uuid4()}"
+        )
+        fs.pipe(path, b"data")
+        assert fs.get_tags(path) == {}
+
+        fs.put_tags(path, {"tag1": "value1"})
+        assert fs.get_tags(path) == {"tag1": "value1"}
+
+        # Merge mode keeps the existing tags.
+        fs.put_tags(path, {"tag2": "value2"}, mode="m")
+        assert fs.get_tags(path) == {"tag1": "value1", "tag2": "value2"}
+
+        # Overwrite mode replaces the existing tags.
+        fs.put_tags(path, {"tag3": "value3"}, mode="o")
+        assert fs.get_tags(path) == {"tag3": "value3"}
+
+    def test_list_and_clear_multipart_uploads(self, fs):
+        bucket = ENV.s3_staging_bucket
+        key = f"{ENV.s3_staging_key}{ENV.schema}/filesystem/test_multipart_uploads/{uuid.uuid4()}"
+        upload = fs._create_multipart_upload(bucket=bucket, key=key)
+
+        uploads = fs.list_multipart_uploads(bucket)
+        listed = next((u for u in uploads if u.upload_id == upload.upload_id), None)
+        assert listed
+        assert listed.bucket == bucket
+        assert listed.key == key
+        assert listed.initiated
+
+        fs.clear_multipart_uploads(bucket)
+        uploads = fs.list_multipart_uploads(f"s3://{bucket}")
+        assert not any(u.upload_id == upload.upload_id for u in uploads)
+
+    def test_file_url_metadata_getxattr_setxattr(self, fs):
+        path = (
+            f"s3://{ENV.s3_staging_bucket}/{ENV.s3_staging_key}{ENV.schema}/"
+            f"filesystem/test_file_helpers/{uuid.uuid4()}"
+        )
+        data = b"0123456789"
+        fs.pipe(path, data)
+        fs.setxattr(path, attr_1="value1")
+
+        with fs.open(path, "rb") as f:
+            assert f.metadata() == {"attr-1": "value1"}
+            assert f.getxattr("attr_1") == "value1"
+            url = f.url(expiration=100)
+            with urllib.request.urlopen(url) as r:
+                assert r.read() == data
+
+        with fs.open(path, "wb") as f:
+            with pytest.raises(NotImplementedError):
+                f.setxattr(attr_2="value2")
+            f.write(data)
+
     def test_pandas_read_csv(self):
         import pandas
 
@@ -873,6 +981,318 @@ class TestS3FileSystem:
             pandas.testing.assert_frame_equal(actual, df)
 
 
+class TestS3FileSystemMocked:
+    """Unit tests for S3FileSystem methods with a mocked client (no AWS access)."""
+
+    @staticmethod
+    def _make_fs():
+        # Build a minimal S3FileSystem without touching AWS, bypassing
+        # __init__ which would require a boto3 client.
+        fs = S3FileSystem.__new__(S3FileSystem)
+        fs.dircache = {}
+        fs._client = mock.MagicMock()
+        fs._call = mock.MagicMock()
+        fs._retry_config = RetryConfig()
+        fs.request_kwargs = {}
+        return fs
+
+    def test_call_translates_client_error(self):
+        fs = self._make_fs()
+        del fs._call  # Use the real method instead of the mock.
+        func = mock.MagicMock(
+            side_effect=botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}}, "HeadObject"
+            )
+        )
+        with pytest.raises(PermissionError, match="Access Denied"):
+            fs._call(func)
+
+    def test_ls_from_cache_with_cached_object(self):
+        fs = self._make_fs()
+        obj = S3Object(
+            init={
+                "ContentLength": 4,
+                "ContentType": None,
+                "StorageClass": S3StorageClass.S3_STORAGE_CLASS_STANDARD,
+                "ETag": '"etag"',
+                "LastModified": None,
+            },
+            type=S3ObjectType.S3_OBJECT_TYPE_FILE,
+            bucket="bucket",
+            key="key",
+        )
+        fs.dircache["bucket/key"] = obj
+
+        assert fs._ls_from_cache("bucket/key") is obj
+        # A child path of a cached object entry must not fail; it falls
+        # through to the S3 API instead (fsspec's implementation assumes
+        # every cache value is a listing and raises TypeError here).
+        assert fs._ls_from_cache("bucket/key/child") is None
+
+    def test_mkdir_creates_bucket(self):
+        fs = self._make_fs()
+        fs.exists = mock.MagicMock(return_value=False)
+        fs._client.meta.region_name = "ap-northeast-1"
+
+        fs.mkdir("s3://new-bucket")
+        fs._call.assert_called_once_with(
+            fs._client.create_bucket,
+            Bucket="new-bucket",
+            CreateBucketConfiguration={"LocationConstraint": "ap-northeast-1"},
+        )
+
+    def test_mkdir_creates_bucket_in_us_east_1_without_location_constraint(self):
+        fs = self._make_fs()
+        fs.exists = mock.MagicMock(return_value=False)
+        fs._client.meta.region_name = "us-east-1"
+
+        fs.mkdir("s3://new-bucket")
+        fs._call.assert_called_once_with(fs._client.create_bucket, Bucket="new-bucket")
+
+    def test_mkdir_creates_bucket_with_acl(self):
+        fs = self._make_fs()
+        fs.exists = mock.MagicMock(return_value=False)
+        fs._client.meta.region_name = "us-east-1"
+
+        fs.mkdir("s3://new-bucket", acl="private")
+        fs._call.assert_called_once_with(
+            fs._client.create_bucket, Bucket="new-bucket", ACL="private"
+        )
+
+        with pytest.raises(ValueError, match="ACL not in"):
+            fs.mkdir("s3://another-bucket", acl="invalid-acl")
+
+    def test_mkdir_existing_bucket_raises(self):
+        fs = self._make_fs()
+        fs.exists = mock.MagicMock(return_value=True)
+
+        with pytest.raises(FileExistsError):
+            fs.mkdir("s3://bucket")
+        fs._call.assert_not_called()
+
+    def test_mkdir_key_under_existing_bucket_is_noop(self):
+        fs = self._make_fs()
+        fs.exists = mock.MagicMock(return_value=True)
+
+        fs.mkdir("s3://bucket/path/to/dir")
+        fs._call.assert_not_called()
+
+    def test_mkdir_key_without_create_parents_checks_bucket(self):
+        fs = self._make_fs()
+        fs.exists = mock.MagicMock(return_value=False)
+        fs.ls = mock.MagicMock(side_effect=FileNotFoundError("bucket"))
+
+        with pytest.raises(FileNotFoundError):
+            fs.mkdir("s3://bucket/path/to/dir", create_parents=False)
+        fs._call.assert_not_called()
+
+    def test_makedirs_exist_ok(self):
+        fs = self._make_fs()
+        fs.mkdir = mock.MagicMock(side_effect=FileExistsError("bucket"))
+
+        fs.makedirs("s3://bucket", exist_ok=True)
+        with pytest.raises(FileExistsError):
+            fs.makedirs("s3://bucket", exist_ok=False)
+
+    def test_rmdir_deletes_bucket(self):
+        fs = self._make_fs()
+
+        fs.rmdir("s3://bucket")
+        fs._call.assert_called_once_with(fs._client.delete_bucket, Bucket="bucket")
+
+    def test_rmdir_key_raises(self):
+        fs = self._make_fs()
+        fs.exists = mock.MagicMock(return_value=True)
+        with pytest.raises(FileExistsError):
+            fs.rmdir("s3://bucket/existing-key")
+
+        fs.exists = mock.MagicMock(return_value=False)
+        with pytest.raises(FileNotFoundError):
+            fs.rmdir("s3://bucket/nonexistent-key")
+        fs._call.assert_not_called()
+
+    def test_metadata(self):
+        fs = self._make_fs()
+        fs._call.return_value = {"Metadata": {"foo_bar": "baz"}}
+
+        assert fs.metadata("s3://bucket/key") == {"foo-bar": "baz"}
+        fs._call.assert_called_once_with(fs._client.head_object, Bucket="bucket", Key="key")
+
+    def test_metadata_with_version_id(self):
+        fs = self._make_fs()
+        fs._call.return_value = {"Metadata": {}}
+
+        assert fs.metadata("s3://bucket/key?versionId=12345abcde") == {}
+        fs._call.assert_called_once_with(
+            fs._client.head_object, Bucket="bucket", Key="key", VersionId="12345abcde"
+        )
+
+    def test_metadata_bucket_raises(self):
+        fs = self._make_fs()
+        with pytest.raises(ValueError, match="Cannot get metadata"):
+            fs.metadata("s3://bucket")
+
+    def test_getxattr(self):
+        fs = self._make_fs()
+        fs.metadata = mock.MagicMock(return_value={"attr-1": "value1"})
+
+        assert fs.getxattr("s3://bucket/key", "attr_1") == "value1"
+        assert fs.getxattr("s3://bucket/key", "attr-1") == "value1"
+        assert fs.getxattr("s3://bucket/key", "missing") is None
+
+    def test_setxattr(self):
+        fs = self._make_fs()
+        fs.metadata = mock.MagicMock(return_value={"attr-1": "value1", "attr-2": "value2"})
+
+        fs.setxattr(
+            "s3://bucket/key",
+            copy_kwargs={"ContentType": "text/plain"},
+            attr_2=None,
+            attr_3="value3",
+        )
+        fs._call.assert_called_once_with(
+            fs._client.copy_object,
+            CopySource={"Bucket": "bucket", "Key": "key"},
+            Bucket="bucket",
+            Key="key",
+            Metadata={"attr-1": "value1", "attr-3": "value3"},
+            MetadataDirective="REPLACE",
+            ContentType="text/plain",
+        )
+
+    def test_setxattr_bucket_raises(self):
+        fs = self._make_fs()
+        with pytest.raises(ValueError, match="Cannot set metadata"):
+            fs.setxattr("s3://bucket", attr_1="value1")
+
+    def test_get_tags(self):
+        fs = self._make_fs()
+        fs._call.return_value = {"TagSet": [{"Key": "tag1", "Value": "value1"}]}
+
+        assert fs.get_tags("s3://bucket/key") == {"tag1": "value1"}
+        fs._call.assert_called_once_with(fs._client.get_object_tagging, Bucket="bucket", Key="key")
+
+    def test_put_tags_overwrite(self):
+        fs = self._make_fs()
+        fs.get_tags = mock.MagicMock(return_value={"tag1": "value1"})
+
+        fs.put_tags("s3://bucket/key", {"tag2": "value2"})
+        fs.get_tags.assert_not_called()
+        fs._call.assert_called_once_with(
+            fs._client.put_object_tagging,
+            Bucket="bucket",
+            Key="key",
+            Tagging={"TagSet": [{"Key": "tag2", "Value": "value2"}]},
+        )
+
+    def test_put_tags_merge(self):
+        fs = self._make_fs()
+        fs.get_tags = mock.MagicMock(return_value={"tag1": "value1"})
+
+        fs.put_tags("s3://bucket/key", {"tag2": "value2"}, mode="m")
+        fs._call.assert_called_once_with(
+            fs._client.put_object_tagging,
+            Bucket="bucket",
+            Key="key",
+            Tagging={
+                "TagSet": [
+                    {"Key": "tag1", "Value": "value1"},
+                    {"Key": "tag2", "Value": "value2"},
+                ]
+            },
+        )
+
+    def test_put_tags_invalid_mode_raises(self):
+        fs = self._make_fs()
+        with pytest.raises(ValueError, match="Mode must be"):
+            fs.put_tags("s3://bucket/key", {"tag1": "value1"}, mode="x")
+
+    def test_chmod_object(self):
+        fs = self._make_fs()
+
+        fs.chmod("s3://bucket/key", "bucket-owner-full-control")
+        fs._call.assert_called_once_with(
+            fs._client.put_object_acl,
+            Bucket="bucket",
+            Key="key",
+            ACL="bucket-owner-full-control",
+        )
+
+    def test_chmod_bucket(self):
+        fs = self._make_fs()
+
+        fs.chmod("s3://bucket", "private")
+        fs._call.assert_called_once_with(fs._client.put_bucket_acl, Bucket="bucket", ACL="private")
+
+    def test_chmod_invalid_acl_raises(self):
+        fs = self._make_fs()
+        with pytest.raises(ValueError, match="ACL not in"):
+            fs.chmod("s3://bucket/key", "invalid-acl")
+        with pytest.raises(ValueError, match="ACL not in"):
+            # A valid object ACL that is not valid for buckets.
+            fs.chmod("s3://bucket", "bucket-owner-full-control")
+        fs._call.assert_not_called()
+
+    def test_chmod_recursive(self):
+        fs = self._make_fs()
+        fs.find = mock.MagicMock(return_value=["bucket/key1", "bucket/key2"])
+
+        fs.chmod("s3://bucket/path", "private", recursive=True)
+        assert fs._call.call_count == 2
+        fs._call.assert_any_call(
+            fs._client.put_object_acl, Bucket="bucket", Key="key1", ACL="private"
+        )
+        fs._call.assert_any_call(
+            fs._client.put_object_acl, Bucket="bucket", Key="key2", ACL="private"
+        )
+
+    def test_list_multipart_uploads_paginates(self):
+        fs = self._make_fs()
+        fs._call.side_effect = [
+            {
+                "Uploads": [{"Key": "key1", "UploadId": "upload1"}],
+                "IsTruncated": True,
+                "NextKeyMarker": "key1",
+                "NextUploadIdMarker": "upload1",
+            },
+            {
+                "Uploads": [{"Key": "key2", "UploadId": "upload2"}],
+                "IsTruncated": False,
+            },
+        ]
+
+        actual = fs.list_multipart_uploads("s3://bucket")
+        assert [(u.bucket, u.key, u.upload_id) for u in actual] == [
+            ("bucket", "key1", "upload1"),
+            ("bucket", "key2", "upload2"),
+        ]
+        fs._call.assert_any_call(fs._client.list_multipart_uploads, Bucket="bucket")
+        fs._call.assert_any_call(
+            fs._client.list_multipart_uploads,
+            Bucket="bucket",
+            KeyMarker="key1",
+            UploadIdMarker="upload1",
+        )
+
+    def test_clear_multipart_uploads(self):
+        fs = self._make_fs()
+        fs.list_multipart_uploads = mock.MagicMock(
+            return_value=[
+                SimpleNamespace(key="key1", upload_id="upload1"),
+                SimpleNamespace(key="key2", upload_id="upload2"),
+            ]
+        )
+
+        fs.clear_multipart_uploads("bucket")
+        assert fs._call.call_count == 2
+        fs._call.assert_any_call(
+            fs._client.abort_multipart_upload, Bucket="bucket", Key="key1", UploadId="upload1"
+        )
+        fs._call.assert_any_call(
+            fs._client.abort_multipart_upload, Bucket="bucket", Key="key2", UploadId="upload2"
+        )
+
+
 class TestS3File:
     @staticmethod
     def _make_write_file(data: bytes, autocommit: bool):
@@ -890,6 +1310,7 @@ class TestS3File:
         file.multipart_upload_parts = []
         file.buffer = io.BytesIO(data)
         file.loc = len(data)  # tell() returns self.loc
+        file._executor = mock.MagicMock()
         return file
 
     @staticmethod
@@ -1027,3 +1448,43 @@ class TestS3File:
             file.commit()
         file.fs._complete_multipart_upload.assert_called_once()
         file.fs._put_object.assert_not_called()
+
+    def test_url_delegates_to_sign(self):
+        file = self._make_write_file(b"", autocommit=True)
+        file.fs.sign.return_value = "https://signed-url"
+
+        assert file.url(expiration=100) == "https://signed-url"
+        file.fs.sign.assert_called_once_with("s3://bucket/key.txt", expiration=100)
+
+    def test_metadata_and_getxattr_delegate_to_fs(self):
+        file = self._make_write_file(b"", autocommit=True)
+        file.fs.metadata.return_value = {"attr-1": "value1"}
+        file.fs.getxattr.return_value = "value1"
+
+        assert file.metadata() == {"attr-1": "value1"}
+        file.fs.metadata.assert_called_once_with("s3://bucket/key.txt")
+        assert file.getxattr("attr_1") == "value1"
+        file.fs.getxattr.assert_called_once_with("s3://bucket/key.txt", "attr_1")
+
+    def test_setxattr_write_mode_raises(self):
+        file = self._make_write_file(b"", autocommit=True)
+        file.mode = "wb"
+        file._closed = False
+
+        with pytest.raises(NotImplementedError):
+            file.setxattr(attr_1="value1")
+        file.fs.setxattr.assert_not_called()
+        # Neutralize __del__, which would otherwise try to flush the
+        # partially-constructed file.
+        file._closed = True
+
+    def test_setxattr_read_mode_delegates_to_fs(self):
+        file = self._make_write_file(b"", autocommit=True)
+        file.mode = "rb"
+        file._closed = False
+
+        file.setxattr(copy_kwargs={"ContentType": "text/plain"}, attr_1="value1")
+        file.fs.setxattr.assert_called_once_with(
+            "s3://bucket/key.txt", copy_kwargs={"ContentType": "text/plain"}, attr_1="value1"
+        )
+        file._closed = True

--- a/tests/pyathena/filesystem/test_s3_async.py
+++ b/tests/pyathena/filesystem/test_s3_async.py
@@ -823,9 +823,9 @@ class TestAioS3FileSystem:
         await fs._pipe_file(path, b"data")
 
         assert fs.metadata(path) == {}
-        fs.setxattr(path, attr_1="value1")
-        assert fs.metadata(path) == {"attr-1": "value1"}
-        assert fs.getxattr(path, "attr_1") == "value1"
+        fs.setxattr(path, attr1="value1")
+        assert fs.metadata(path) == {"attr1": "value1"}
+        assert fs.getxattr(path, "attr1") == "value1"
         assert fs.getxattr(path, "missing") is None
 
         assert fs.get_tags(path) == {}

--- a/tests/pyathena/filesystem/test_s3_async.py
+++ b/tests/pyathena/filesystem/test_s3_async.py
@@ -796,6 +796,42 @@ class TestAioS3FileSystem:
         assert requested + 100 < expires
         assert data == b"0123456789"
 
+    @pytest.mark.asyncio
+    async def test_mkdir_and_rmdir(self, fs):
+        # The bucket already exists.
+        with pytest.raises(FileExistsError):
+            await fs._mkdir(f"s3://{ENV.s3_staging_bucket}")
+        await fs._makedirs(f"s3://{ENV.s3_staging_bucket}", exist_ok=True)
+
+        path = (
+            f"s3://{ENV.s3_staging_bucket}/{ENV.s3_staging_key}{ENV.schema}/"
+            f"filesystem/test_async_rmdir/{uuid.uuid4()}"
+        )
+        await fs._pipe_file(path, b"data")
+        # Only bucket paths can be removed.
+        with pytest.raises(FileExistsError):
+            await fs._rmdir(path)
+        with pytest.raises(FileNotFoundError):
+            fs.rmdir(f"{path}/nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_metadata_and_tags(self, fs):
+        path = (
+            f"s3://{ENV.s3_staging_bucket}/{ENV.s3_staging_key}{ENV.schema}/"
+            f"filesystem/test_async_metadata/{uuid.uuid4()}"
+        )
+        await fs._pipe_file(path, b"data")
+
+        assert fs.metadata(path) == {}
+        fs.setxattr(path, attr_1="value1")
+        assert fs.metadata(path) == {"attr-1": "value1"}
+        assert fs.getxattr(path, "attr_1") == "value1"
+        assert fs.getxattr(path, "missing") is None
+
+        assert fs.get_tags(path) == {}
+        fs.put_tags(path, {"tag1": "value1"})
+        assert fs.get_tags(path) == {"tag1": "value1"}
+
     def test_pandas_read_csv(self):
         import pandas
 

--- a/tests/pyathena/filesystem/test_s3_errors.py
+++ b/tests/pyathena/filesystem/test_s3_errors.py
@@ -1,0 +1,83 @@
+import errno
+
+import botocore.exceptions
+import pytest
+
+from pyathena.filesystem.s3_errors import translate_client_error
+
+
+def _client_error(code, message="error message", status_code=None):
+    error_response = {"Error": {"Code": code, "Message": message}}
+    if status_code is not None:
+        error_response["ResponseMetadata"] = {"HTTPStatusCode": status_code}
+    return botocore.exceptions.ClientError(error_response, "TestOperation")
+
+
+@pytest.mark.parametrize(
+    ("code", "expected"),
+    [
+        ("AccessDenied", PermissionError),
+        ("403", PermissionError),
+        ("InvalidAccessKeyId", PermissionError),
+        ("ExpiredToken", PermissionError),
+        ("SignatureDoesNotMatch", PermissionError),
+        ("NoSuchKey", FileNotFoundError),
+        ("NoSuchBucket", FileNotFoundError),
+        ("NoSuchUpload", FileNotFoundError),
+        ("NoSuchVersion", FileNotFoundError),
+        ("404", FileNotFoundError),
+        ("BucketAlreadyExists", FileExistsError),
+        ("BucketAlreadyOwnedByYou", FileExistsError),
+        ("RequestTimeout", TimeoutError),
+    ],
+)
+def test_translate_client_error_to_exception(code, expected):
+    actual = translate_client_error(_client_error(code))
+    assert type(actual) is expected
+    assert "error message" in str(actual)
+
+
+@pytest.mark.parametrize(
+    ("code", "expected_errno"),
+    [
+        ("BucketNotEmpty", errno.ENOTEMPTY),
+        ("SlowDown", errno.EBUSY),
+        ("ServiceUnavailable", errno.EBUSY),
+        ("OperationAborted", errno.EBUSY),
+        ("MethodNotAllowed", errno.EPERM),
+        ("InternalError", errno.EIO),
+    ],
+)
+def test_translate_client_error_to_os_error(code, expected_errno):
+    actual = translate_client_error(_client_error(code))
+    # OSError specializes itself into a subclass for some errno values
+    # (e.g., EPERM -> PermissionError), so check the errno, not the exact type.
+    assert isinstance(actual, OSError)
+    assert actual.errno == expected_errno
+    assert "error message" in str(actual)
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected_errno"),
+    [
+        (400, errno.EINVAL),
+        (405, errno.EPERM),
+        (409, errno.EBUSY),
+        (412, errno.EINVAL),
+        (416, errno.EINVAL),
+        (500, errno.EIO),
+        (501, errno.ENOSYS),
+        (503, errno.EBUSY),
+    ],
+)
+def test_translate_client_error_by_http_status_code(status_code, expected_errno):
+    actual = translate_client_error(_client_error("UnknownCode", status_code=status_code))
+    assert isinstance(actual, OSError)
+    assert actual.errno == expected_errno
+
+
+def test_translate_client_error_unknown_code():
+    actual = translate_client_error(_client_error("UnknownCode"))
+    assert type(actual) is OSError
+    assert actual.errno == errno.EIO
+    assert "error message" in str(actual)

--- a/tests/pyathena/filesystem/test_s3_errors.py
+++ b/tests/pyathena/filesystem/test_s3_errors.py
@@ -44,7 +44,6 @@ def test_translate_client_error_to_exception(code, expected):
         ("SlowDown", errno.EBUSY),
         ("ServiceUnavailable", errno.EBUSY),
         ("OperationAborted", errno.EBUSY),
-        ("MethodNotAllowed", errno.EPERM),
         ("InternalError", errno.EIO),
     ],
 )

--- a/tests/pyathena/filesystem/test_s3_errors.py
+++ b/tests/pyathena/filesystem/test_s3_errors.py
@@ -3,7 +3,7 @@ import errno
 import botocore.exceptions
 import pytest
 
-from pyathena.filesystem.s3_errors import translate_client_error
+from pyathena.filesystem.s3_errors import S3ClientError
 
 
 def _client_error(code, message="error message", status_code=None):
@@ -13,70 +13,77 @@ def _client_error(code, message="error message", status_code=None):
     return botocore.exceptions.ClientError(error_response, "TestOperation")
 
 
-@pytest.mark.parametrize(
-    ("code", "expected"),
-    [
-        ("AccessDenied", PermissionError),
-        ("403", PermissionError),
-        ("InvalidAccessKeyId", PermissionError),
-        ("ExpiredToken", PermissionError),
-        ("SignatureDoesNotMatch", PermissionError),
-        ("NoSuchKey", FileNotFoundError),
-        ("NoSuchBucket", FileNotFoundError),
-        ("NoSuchUpload", FileNotFoundError),
-        ("NoSuchVersion", FileNotFoundError),
-        ("404", FileNotFoundError),
-        ("BucketAlreadyExists", FileExistsError),
-        ("BucketAlreadyOwnedByYou", FileExistsError),
-        ("RequestTimeout", TimeoutError),
-    ],
-)
-def test_translate_client_error_to_exception(code, expected):
-    actual = translate_client_error(_client_error(code))
-    assert type(actual) is expected
-    assert "error message" in str(actual)
+class TestS3ClientError:
+    def test_properties(self):
+        error = S3ClientError(_client_error("NoSuchKey", status_code=404))
+        assert error.code == "NoSuchKey"
+        assert error.message == "error message"
+        assert error.http_status_code == 404
 
+        error = S3ClientError(_client_error("NoSuchKey"))
+        assert error.http_status_code is None
 
-@pytest.mark.parametrize(
-    ("code", "expected_errno"),
-    [
-        ("BucketNotEmpty", errno.ENOTEMPTY),
-        ("SlowDown", errno.EBUSY),
-        ("ServiceUnavailable", errno.EBUSY),
-        ("OperationAborted", errno.EBUSY),
-        ("InternalError", errno.EIO),
-    ],
-)
-def test_translate_client_error_to_os_error(code, expected_errno):
-    actual = translate_client_error(_client_error(code))
-    # OSError specializes itself into a subclass for some errno values
-    # (e.g., EPERM -> PermissionError), so check the errno, not the exact type.
-    assert isinstance(actual, OSError)
-    assert actual.errno == expected_errno
-    assert "error message" in str(actual)
+    @pytest.mark.parametrize(
+        ("code", "expected"),
+        [
+            ("AccessDenied", PermissionError),
+            ("403", PermissionError),
+            ("InvalidAccessKeyId", PermissionError),
+            ("ExpiredToken", PermissionError),
+            ("SignatureDoesNotMatch", PermissionError),
+            ("NoSuchKey", FileNotFoundError),
+            ("NoSuchBucket", FileNotFoundError),
+            ("NoSuchUpload", FileNotFoundError),
+            ("NoSuchVersion", FileNotFoundError),
+            ("404", FileNotFoundError),
+            ("BucketAlreadyExists", FileExistsError),
+            ("BucketAlreadyOwnedByYou", FileExistsError),
+            ("RequestTimeout", TimeoutError),
+        ],
+    )
+    def test_os_error_by_error_code(self, code, expected):
+        actual = S3ClientError(_client_error(code)).os_error
+        assert type(actual) is expected
+        assert "error message" in str(actual)
 
+    @pytest.mark.parametrize(
+        ("code", "expected_errno"),
+        [
+            ("BucketNotEmpty", errno.ENOTEMPTY),
+            ("SlowDown", errno.EBUSY),
+            ("ServiceUnavailable", errno.EBUSY),
+            ("OperationAborted", errno.EBUSY),
+            ("InternalError", errno.EIO),
+        ],
+    )
+    def test_os_error_by_error_code_errno(self, code, expected_errno):
+        actual = S3ClientError(_client_error(code)).os_error
+        # OSError specializes itself into a subclass for some errno values
+        # (e.g., EPERM -> PermissionError), so check the errno, not the exact type.
+        assert isinstance(actual, OSError)
+        assert actual.errno == expected_errno
+        assert "error message" in str(actual)
 
-@pytest.mark.parametrize(
-    ("status_code", "expected_errno"),
-    [
-        (400, errno.EINVAL),
-        (405, errno.EPERM),
-        (409, errno.EBUSY),
-        (412, errno.EINVAL),
-        (416, errno.EINVAL),
-        (500, errno.EIO),
-        (501, errno.ENOSYS),
-        (503, errno.EBUSY),
-    ],
-)
-def test_translate_client_error_by_http_status_code(status_code, expected_errno):
-    actual = translate_client_error(_client_error("UnknownCode", status_code=status_code))
-    assert isinstance(actual, OSError)
-    assert actual.errno == expected_errno
+    @pytest.mark.parametrize(
+        ("status_code", "expected_errno"),
+        [
+            (400, errno.EINVAL),
+            (405, errno.EPERM),
+            (409, errno.EBUSY),
+            (412, errno.EINVAL),
+            (416, errno.EINVAL),
+            (500, errno.EIO),
+            (501, errno.ENOSYS),
+            (503, errno.EBUSY),
+        ],
+    )
+    def test_os_error_by_http_status_code(self, status_code, expected_errno):
+        actual = S3ClientError(_client_error("UnknownCode", status_code=status_code)).os_error
+        assert isinstance(actual, OSError)
+        assert actual.errno == expected_errno
 
-
-def test_translate_client_error_unknown_code():
-    actual = translate_client_error(_client_error("UnknownCode"))
-    assert type(actual) is OSError
-    assert actual.errno == errno.EIO
-    assert "error message" in str(actual)
+    def test_os_error_unknown_code(self):
+        actual = S3ClientError(_client_error("UnknownCode")).os_error
+        assert type(actual) is OSError
+        assert actual.errno == errno.EIO
+        assert "error message" in str(actual)

--- a/tests/pyathena/filesystem/test_s3_object.py
+++ b/tests/pyathena/filesystem/test_s3_object.py
@@ -148,6 +148,10 @@ class TestS3MultipartUpload:
                 "BucketKeyEnabled": True,
                 "RequestCharged": "requester",
                 "ChecksumAlgorithm": "CRC32",
+                "Initiated": datetime(2015, 1, 1, 0, 0, 0),
+                "StorageClass": "STANDARD",
+                "Owner": {"DisplayName": "test_owner", "ID": "test_owner_id"},
+                "Initiator": {"DisplayName": "test_initiator", "ID": "test_initiator_id"},
             }
         )
         assert actual.abort_date == datetime(2015, 1, 1, 0, 0, 0)
@@ -163,6 +167,27 @@ class TestS3MultipartUpload:
         assert actual.bucket_key_enabled is True
         assert actual.request_charged == "requester"
         assert actual.checksum_algorithm == "CRC32"
+        assert actual.initiated == datetime(2015, 1, 1, 0, 0, 0)
+        assert actual.storage_class == "STANDARD"
+        assert actual.owner
+        assert actual.owner.display_name == "test_owner"
+        assert actual.owner.id == "test_owner_id"
+        assert actual.initiator
+        assert actual.initiator.display_name == "test_initiator"
+        assert actual.initiator.id == "test_initiator_id"
+
+    def test_init_without_list_fields(self):
+        actual = S3MultipartUpload(
+            {
+                "Bucket": "test_bucket",
+                "Key": "test_key",
+                "UploadId": "test_upload_id",
+            }
+        )
+        assert actual.initiated is None
+        assert actual.storage_class is None
+        assert actual.owner is None
+        assert actual.initiator is None
 
 
 class TestS3MultipartUploadPart:

--- a/tests/pyathena/filesystem/test_s3_object.py
+++ b/tests/pyathena/filesystem/test_s3_object.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from pyathena.filesystem.s3_object import (
     S3CompleteMultipartUpload,
+    S3Metadata,
     S3MultipartUpload,
     S3MultipartUploadPart,
     S3Object,
@@ -93,6 +94,76 @@ class TestS3Object:
             "ContentType": "application/json",
             "StorageClass": "STANDARD",
         }
+
+
+class TestS3Metadata:
+    def test_init(self):
+        actual = S3Metadata(
+            {
+                "CacheControl": "no-cache",
+                "ContentDisposition": "attachment",
+                "ContentEncoding": "gzip",
+                "ContentLanguage": "en",
+                "ContentLength": 1024,
+                "ContentType": "text/plain",
+                "ETag": '"test_etag"',
+                "Expiration": "test_expiration",
+                "Expires": datetime(2015, 1, 1, 0, 0, 0),
+                "LastModified": datetime(2015, 1, 2, 0, 0, 0),
+                "StorageClass": "STANDARD_IA",
+                "ServerSideEncryption": "AES256",
+                "SSECustomerAlgorithm": "test_sse_customer_algorithm",
+                "SSEKMSKeyId": "test_sse_kms_key_id",
+                "BucketKeyEnabled": True,
+                "WebsiteRedirectLocation": "test_website_redirect_location",
+                "VersionId": "test_version_id",
+                "Metadata": {"attr1": "value1", "attr-2": "value2"},
+            }
+        )
+        assert actual.cache_control == "no-cache"
+        assert actual.content_disposition == "attachment"
+        assert actual.content_encoding == "gzip"
+        assert actual.content_language == "en"
+        assert actual.content_length == 1024
+        assert actual.content_type == "text/plain"
+        assert actual.etag == '"test_etag"'
+        assert actual.expiration == "test_expiration"
+        assert actual.expires == datetime(2015, 1, 1, 0, 0, 0)
+        assert actual.last_modified == datetime(2015, 1, 2, 0, 0, 0)
+        assert actual.storage_class == "STANDARD_IA"
+        assert actual.server_side_encryption == "AES256"
+        assert actual.sse_customer_algorithm == "test_sse_customer_algorithm"
+        assert actual.sse_kms_key_id == "test_sse_kms_key_id"
+        assert actual.bucket_key_enabled is True
+        assert actual.website_redirect_location == "test_website_redirect_location"
+        assert actual.version_id == "test_version_id"
+        assert actual.user_metadata == {"attr1": "value1", "attr-2": "value2"}
+
+    def test_init_defaults(self):
+        actual = S3Metadata({})
+        assert actual.content_type is None
+        # StorageClass is omitted from responses for S3 Standard objects.
+        assert actual.storage_class == S3StorageClass.S3_STORAGE_CLASS_STANDARD
+        assert actual.user_metadata == {}
+        assert actual == {}
+
+    def test_mapping_interface(self):
+        # The mapping interface exposes the user-defined metadata, so the
+        # object is a drop-in for a plain user-metadata dictionary.
+        actual = S3Metadata(
+            {"ContentType": "text/plain", "Metadata": {"attr1": "value1", "attr-2": "value2"}}
+        )
+        assert actual["attr1"] == "value1"
+        assert actual.get("attr-2") == "value2"
+        assert actual.get("missing") is None
+        assert "attr1" in actual
+        assert len(actual) == 2
+        assert sorted(actual) == ["attr-2", "attr1"]
+        assert dict(actual) == {"attr1": "value1", "attr-2": "value2"}
+        assert actual == {"attr1": "value1", "attr-2": "value2"}
+        assert actual != {"attr1": "value1"}
+        # System-defined metadata is not part of the mapping.
+        assert "content_type" not in actual
 
 
 class TestS3PutObject:


### PR DESCRIPTION
## WHAT

Implements several items from the filesystem API parity checklist in #722, designed around PyAthena's existing architecture (typed model classes, sync boto3 client with executor-based parallelism) rather than porting s3fs code:

- **Error translation**: botocore `ClientError` responses are now translated into standard Python exceptions at the `S3FileSystem._call` chokepoint (e.g. `403` → `PermissionError`, `404` → `FileNotFoundError`, `BucketNotEmpty` → `OSError(ENOTEMPTY)`). The new `pyathena.filesystem.s3_errors.S3ClientError` class owns the mapping tables and rules, resolves the translation once in its constructor, and exposes it via the `os_error` property; error codes are verified against the official S3 error code list (`API_Error.html`), mapped by S3 error code first and HTTP status code as fallback. Note: code that previously caught raw `botocore.exceptions.ClientError` around filesystem calls should catch `OSError` subclasses instead.
- **Directory operations**: `mkdir` / `makedirs` / `rmdir`. Bucket creation/deletion is **disabled by default** (bucket lifecycle is an infrastructure-level change) and raises `PermissionError` with an explanatory message; the `allow_bucket_creation` / `allow_bucket_deletion` constructor flags opt in (canned-ACL and region support on creation). Key prefixes under an existing bucket are a no-op, and non-mutating paths (existence checks, key-path validation) work regardless of the flags.
- **Object metadata & attributes**: `metadata` / `getxattr` / `setxattr` (user-defined `x-amz-meta-*` metadata), `get_tags` / `put_tags` (object tagging with overwrite/merge modes), and `chmod` (canned ACLs on objects/buckets, optional recursive).
- **Multipart upload management**: `list_multipart_uploads` (paginated, returns typed `S3MultipartUpload` instances) and `clear_multipart_uploads` to abort stale/incomplete MPUs.
- **`S3File` helpers**: `url` / `metadata` / `getxattr` / `setxattr`.
- **`AioS3FileSystem`**: delegates for all of the above, following the existing conventions of the class.
- **Model classes**: `S3MultipartUpload` extended with the `ListMultipartUploads` response fields (`Initiated`, `StorageClass`, `Owner`, `Initiator`); new `S3Owner` class.

Also fixes a latent dircache bug exposed by the new tests: fsspec's `_ls_from_cache` assumes every dircache value is a listing, but `S3FileSystem` caches single `S3Object` entries for HeadObject/HeadBucket results, so looking up a child path of a cached object raised `TypeError` (reproducible on master with `fs.info(key)` followed by `fs.exists(key + \"/child\")`).

**Testing**: mocking is kept to a minimum — mocked tests exist only where real AWS is inappropriate (bucket creation/deletion request shapes, ACL updates, VersionId request shapes, MPU pagination, dircache shape handling) plus pure-logic unit tests for `S3ClientError`. Everything else runs against real S3 at the filesystem layer (small objects only, no multipart data uploads): metadata/xattr round-trips, tagging, prefix-scoped MPU list/clear, presigned URL reads, mkdir/rmdir semantics incl. the disabled-by-default `PermissionError`s, and an unsigned-access test locking the `403` → `PermissionError` translation. `just lint` passes and the full filesystem suite (204 tests, including `TestAioS3FileSystem`) passes against real AWS.

## WHY

Part of #722: users migrating from s3fs to the built-in `S3FileSystem` hit missing operations and less useful error types. This PR closes the directory-operation, metadata/tagging/ACL, multipart-management, error-translation, and file-helper gaps.

Remaining checklist items intentionally deferred to follow-up PRs: `version_aware` mode, registry-shadowing DX, direct single-PUT `pipe_file`, and async streaming-read verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
