### PR TITLE
Use f-strings for the remaining log messages

### DIFF
--- a/pyathena/arrow/result_set.py
+++ b/pyathena/arrow/result_set.py
@@ -315,7 +315,7 @@ class AthenaArrowResultSet(AthenaResultSet):
                 ),
             )
         except Exception as e:
-            _logger.exception("Failed to read %s/%s.", bucket, key)
+            _logger.exception(f"Failed to read {bucket}/{key}.")
             raise OperationalError(*e.args) from e
 
     def _read_parquet(self) -> Table:
@@ -333,7 +333,7 @@ class AthenaArrowResultSet(AthenaResultSet):
             dataset = parquet.ParquetDataset(f"{bucket}/{key}", filesystem=self._fs)
             return dataset.read(use_threads=True)
         except Exception as e:
-            _logger.exception("Failed to read %s/%s.", bucket, key)
+            _logger.exception(f"Failed to read {bucket}/{key}.")
             raise OperationalError(*e.args) from e
 
     def _as_arrow(self) -> Table:

--- a/pyathena/pandas/result_set.py
+++ b/pyathena/pandas/result_set.py
@@ -524,9 +524,8 @@ class AthenaPandasResultSet(AthenaResultSet):
             effective_chunksize = self._auto_determine_chunksize(length)
             if effective_chunksize:
                 _logger.debug(
-                    "Auto-determined chunksize: %s for file size: %s bytes",
-                    effective_chunksize,
-                    length,
+                    f"Auto-determined chunksize: {effective_chunksize} "
+                    f"for file size: {length} bytes"
                 )
 
         csv_engine = self._get_csv_engine(length, effective_chunksize)
@@ -565,12 +564,11 @@ class AthenaPandasResultSet(AthenaResultSet):
             # Log performance information for large files
             if length > self.LARGE_FILE_THRESHOLD_BYTES:
                 mode = "chunked" if effective_chunksize else "full"
-                msg = "Reading %s bytes from S3 in %s mode using %s engine"
-                args: tuple[object, ...] = (length, mode, csv_engine)
-                if effective_chunksize:
-                    msg += " with chunksize=%s"
-                    args = (*args, effective_chunksize)
-                _logger.info(msg, *args)
+                chunksize = f" with chunksize={effective_chunksize}" if effective_chunksize else ""
+                _logger.info(
+                    f"Reading {length} bytes from S3 in {mode} mode "
+                    f"using {csv_engine} engine{chunksize}"
+                )
 
             return result
 

--- a/pyathena/pandas/result_set.py
+++ b/pyathena/pandas/result_set.py
@@ -575,7 +575,7 @@ class AthenaPandasResultSet(AthenaResultSet):
             return result
 
         except Exception as e:
-            _logger.exception("Failed to read %s.", self.output_location)
+            _logger.exception(f"Failed to read {self.output_location}.")
             raise OperationalError(*e.args) from e
 
     def _read_parquet(self, engine) -> DataFrame:
@@ -609,7 +609,7 @@ class AthenaPandasResultSet(AthenaResultSet):
                 **kwargs,
             )
         except Exception as e:
-            _logger.exception("Failed to read %s.", self.output_location)
+            _logger.exception(f"Failed to read {self.output_location}.")
             raise OperationalError(*e.args) from e
 
     def _read_parquet_schema(self, engine) -> tuple[dict[str, Any], ...]:
@@ -625,7 +625,7 @@ class AthenaPandasResultSet(AthenaResultSet):
                 dataset = parquet.ParquetDataset(f"{bucket}/{key}", filesystem=self._fs)
                 return to_column_info(dataset.schema)
             except Exception as e:
-                _logger.exception("Failed to read schema %s/%s.", bucket, key)
+                _logger.exception(f"Failed to read schema {bucket}/{key}.")
                 raise OperationalError(*e.args) from e
         else:
             raise ProgrammingError("Engine must be `pyarrow`.")

--- a/pyathena/pandas/util.py
+++ b/pyathena/pandas/util.py
@@ -342,7 +342,7 @@ def to_sql(
             )
         for future in concurrent.futures.as_completed(futures):
             result = future.result()
-            _logger.info("to_parquet: %s", result)
+            _logger.info(f"to_parquet: {result}")
 
     ddl = generate_ddl(
         df=df,

--- a/pyathena/polars/result_set.py
+++ b/pyathena/polars/result_set.py
@@ -472,7 +472,7 @@ class AthenaPolarsResultSet(AthenaResultSet):
                 df.columns = new_columns
             return df
         except Exception as e:
-            _logger.exception("Failed to read %s.", self.output_location)
+            _logger.exception(f"Failed to read {self.output_location}.")
             raise OperationalError(*e.args) from e
 
     def _read_parquet(self) -> pl.DataFrame:
@@ -499,7 +499,7 @@ class AthenaPolarsResultSet(AthenaResultSet):
                 **self._kwargs,
             )
         except Exception as e:
-            _logger.exception("Failed to read %s.", self._unload_location)
+            _logger.exception(f"Failed to read {self._unload_location}.")
             raise OperationalError(*e.args) from e
 
     def _read_parquet_schema(self) -> tuple[dict[str, Any], ...]:
@@ -518,7 +518,7 @@ class AthenaPolarsResultSet(AthenaResultSet):
             schema = lazy_df.collect_schema()
             return to_column_info(schema)
         except Exception as e:
-            _logger.exception("Failed to read schema from %s.", self._unload_location)
+            _logger.exception(f"Failed to read schema from {self._unload_location}.")
             raise OperationalError(*e.args) from e
 
     def _as_polars(self) -> pl.DataFrame:
@@ -658,7 +658,7 @@ class AthenaPolarsResultSet(AthenaResultSet):
                     batch.columns = new_columns
                 yield batch
         except Exception as e:
-            _logger.exception("Failed to read %s.", self.output_location)
+            _logger.exception(f"Failed to read {self.output_location}.")
             raise OperationalError(*e.args) from e
 
     def _iter_parquet_chunks(self) -> Iterator[pl.DataFrame]:
@@ -686,7 +686,7 @@ class AthenaPolarsResultSet(AthenaResultSet):
             )
             yield from lazy_df.collect_batches(chunk_size=self._chunksize)
         except Exception as e:
-            _logger.exception("Failed to read %s.", self._unload_location)
+            _logger.exception(f"Failed to read {self._unload_location}.")
             raise OperationalError(*e.args) from e
 
     def iter_chunks(self) -> PolarsDataFrameIterator:

--- a/pyathena/result_set.py
+++ b/pyathena/result_set.py
@@ -663,7 +663,7 @@ class AthenaResultSet(CursorIterator):
                 Key=key,
             )
         except Exception as e:
-            _logger.exception("Failed to read %s/%s.", bucket, key)
+            _logger.exception(f"Failed to read {bucket}/{key}.")
             raise OperationalError(*e.args) from e
         else:
             manifest: str = response["Body"].read().decode("utf-8").strip()

--- a/pyathena/s3fs/result_set.py
+++ b/pyathena/s3fs/result_set.py
@@ -141,7 +141,7 @@ class AthenaS3FSResultSet(AthenaResultSet):
                 next(self._csv_reader)
 
         except Exception as e:
-            _logger.exception("Failed to open %s.", path)
+            _logger.exception(f"Failed to open {path}.")
             raise OperationalError(*e.args) from e
 
     def _fetch(self) -> None:

--- a/pyathena/spark/common.py
+++ b/pyathena/spark/common.py
@@ -153,7 +153,7 @@ class SparkBaseCursor(BaseCursor, metaclass=ABCMeta):
                 isinstance(e, botocore.exceptions.ClientError)
                 and e.response["Error"]["Code"] == "InvalidRequestException"
             ):
-                _logger.exception("Session: %s not found.", session_id)
+                _logger.exception(f"Session: {session_id} not found.")
                 return False
             raise OperationalError(*e.args) from e
         else:


### PR DESCRIPTION
## WHAT

Converts the remaining %-style logger calls (14 call sites across 7 files: the result-set modules, `pandas/util.py`, and `spark/common.py`) to f-strings. The filesystem modules were already converted in #730, where ruff's `G004` (logging-f-string) rule was moved to the ignore list.

## WHY

Unifies the logging style across the codebase on f-strings, per the maintainer's preference. No behavioral change; the lazy-formatting difference is irrelevant for these exception/info messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)