### PR TITLE
Allow dispatching the test workflow manually

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,10 @@ on:
       - '**.md'
   schedule:
     - cron:  '0 0 * * 0'
+  # Allows refreshing the README status badge on demand: the badge reflects
+  # the latest run on the default branch, which is otherwise only the weekly
+  # scheduled run and stays red for up to a week after a transient failure.
+  workflow_dispatch:
 
 permissions:
   id-token: write


### PR DESCRIPTION
## WHAT

Adds the `workflow_dispatch` trigger to the test workflow.

## WHY

The README status badge reflects the latest run of the workflow on the default branch, which is only the weekly scheduled run (the workflow otherwise runs on `pull_request`). A transient failure there — like the Athena concurrent-query quota stampede that failed the 2026-07-05 scheduled run and pinned the badge red — cannot be refreshed until the next Sunday. With `workflow_dispatch`, the suite can be re-run on master on demand (`gh workflow run test.yaml`) to restore the badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)