### PR TITLE
Restore legacy keyword arguments on the private _execute() methods

### DIFF
--- a/pyathena/aio/common.py
+++ b/pyathena/aio/common.py
@@ -28,9 +28,28 @@ class AioBaseCursor(BaseCursor):
         self,
         operation: str,
         parameters: dict[str, Any] | list[str] | None = None,
+        work_group: str | None = None,
+        s3_staging_dir: str | None = None,
+        cache_size: int | None = None,
+        cache_expiration_time: int | None = None,
+        result_reuse_enable: bool | None = None,
+        result_reuse_minutes: int | None = None,
+        paramstyle: str | None = None,
         options: ExecuteOptions | None = None,
     ) -> str:
-        options = ExecuteOptions.resolve(options)
+        # The individual keyword arguments are retained for backward compatibility
+        # with external callers that predate ExecuteOptions, mirroring
+        # BaseCursor._execute().
+        options = ExecuteOptions.resolve(
+            options,
+            work_group=work_group,
+            s3_staging_dir=s3_staging_dir,
+            cache_size=cache_size,
+            cache_expiration_time=cache_expiration_time,
+            result_reuse_enable=result_reuse_enable,
+            result_reuse_minutes=result_reuse_minutes,
+            paramstyle=paramstyle,
+        )
         query, execution_parameters = self._prepare_query(operation, parameters, options.paramstyle)
 
         request = self._build_start_query_execution_request(

--- a/pyathena/common.py
+++ b/pyathena/common.py
@@ -714,9 +714,28 @@ class BaseCursor(metaclass=ABCMeta):
         self,
         operation: str,
         parameters: dict[str, Any] | list[str] | None = None,
+        work_group: str | None = None,
+        s3_staging_dir: str | None = None,
+        cache_size: int | None = None,
+        cache_expiration_time: int | None = None,
+        result_reuse_enable: bool | None = None,
+        result_reuse_minutes: int | None = None,
+        paramstyle: str | None = None,
         options: ExecuteOptions | None = None,
     ) -> str:
-        options = ExecuteOptions.resolve(options)
+        # The individual keyword arguments are retained for backward compatibility
+        # with external callers that predate ExecuteOptions (e.g. dbt-athena <= 1.10.x
+        # calls _execute() with work_group/s3_staging_dir/cache_* keywords).
+        options = ExecuteOptions.resolve(
+            options,
+            work_group=work_group,
+            s3_staging_dir=s3_staging_dir,
+            cache_size=cache_size,
+            cache_expiration_time=cache_expiration_time,
+            result_reuse_enable=result_reuse_enable,
+            result_reuse_minutes=result_reuse_minutes,
+            paramstyle=paramstyle,
+        )
         query, execution_parameters = self._prepare_query(operation, parameters, options.paramstyle)
 
         request = self._build_start_query_execution_request(

--- a/tests/pyathena/aio/test_cursor.py
+++ b/tests/pyathena/aio/test_cursor.py
@@ -79,6 +79,23 @@ class TestAioCursor:
         assert callback_results == [aio_cursor.query_id]
         assert await aio_cursor.fetchone() == (1,)
 
+    async def test_execute_internal_legacy_kwargs(self, aio_cursor):
+        """The private _execute() accepts the pre-3.35 individual keyword arguments.
+
+        Regression test for #734, mirroring the synchronous cursor test for
+        external callers that invoke _execute() directly with individual keywords.
+        """
+        query_id = await aio_cursor._execute(
+            "SELECT 1",
+            parameters=None,
+            work_group=ENV.default_work_group,
+            s3_staging_dir=None,
+            cache_size=0,
+            cache_expiration_time=0,
+        )
+        query_execution = await aio_cursor._poll(query_id)
+        assert query_execution.state == AthenaQueryExecution.STATE_SUCCEEDED
+
     async def test_no_result_set_raises(self, aio_cursor):
         with pytest.raises(ProgrammingError):
             await aio_cursor.fetchone()

--- a/tests/pyathena/aio/test_cursor.py
+++ b/tests/pyathena/aio/test_cursor.py
@@ -1,12 +1,15 @@
 import re
 from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from pyathena import ExecuteOptions
+from pyathena.aio.cursor import AioCursor
 from pyathena.error import DatabaseError, ProgrammingError
 from pyathena.model import AthenaQueryExecution
 from pyathena.result_set import AthenaResultSet
+from pyathena.util import RetryConfig
 from tests import ENV
 from tests.pyathena.aio.conftest import _aio_connect
 
@@ -79,22 +82,53 @@ class TestAioCursor:
         assert callback_results == [aio_cursor.query_id]
         assert await aio_cursor.fetchone() == (1,)
 
-    async def test_execute_internal_legacy_kwargs(self, aio_cursor):
-        """The private _execute() accepts the pre-3.35 individual keyword arguments.
+    async def test_execute_internal_legacy_kwargs_passthrough(self):
+        """The pre-3.35 _execute() keywords are forwarded to the request (no AWS).
 
-        Regression test for #734, mirroring the synchronous cursor test for
-        external callers that invoke _execute() directly with individual keywords.
+        Mirrors the synchronous cursor test (regression test for #734).
         """
-        query_id = await aio_cursor._execute(
-            "SELECT 1",
-            parameters=None,
-            work_group=ENV.default_work_group,
-            s3_staging_dir=None,
-            cache_size=0,
-            cache_expiration_time=0,
+        cursor = AioCursor.__new__(AioCursor)  # bypass __init__ to avoid AWS calls
+        cursor._connection = MagicMock()
+        cursor._connection.client.start_query_execution.return_value = {
+            "QueryExecutionId": "test_query_id"
+        }
+        cursor._retry_config = RetryConfig()
+
+        with (
+            patch.object(
+                AioCursor, "_build_start_query_execution_request", return_value={}
+            ) as request_mock,
+            patch.object(
+                AioCursor, "_find_previous_query_id", new_callable=AsyncMock, return_value=None
+            ) as cache_mock,
+        ):
+            query_id = await cursor._execute(
+                "SELECT 1",
+                parameters=None,
+                work_group="test_work_group",
+                s3_staging_dir="s3://test-bucket/path/",
+                cache_size=10,
+                cache_expiration_time=100,
+                result_reuse_enable=True,
+                result_reuse_minutes=5,
+                paramstyle="qmark",
+            )
+
+        assert query_id == "test_query_id"
+        request_mock.assert_called_once_with(
+            query="SELECT 1",
+            work_group="test_work_group",
+            s3_staging_dir="s3://test-bucket/path/",
+            result_reuse_enable=True,
+            result_reuse_minutes=5,
+            execution_parameters=None,
         )
-        query_execution = await aio_cursor._poll(query_id)
-        assert query_execution.state == AthenaQueryExecution.STATE_SUCCEEDED
+        cache_mock.assert_awaited_once_with(
+            "SELECT 1",
+            "test_work_group",
+            cache_size=10,
+            cache_expiration_time=100,
+        )
 
     async def test_no_result_set_raises(self, aio_cursor):
         with pytest.raises(ProgrammingError):

--- a/tests/pyathena/test_cursor.py
+++ b/tests/pyathena/test_cursor.py
@@ -20,6 +20,7 @@ from pyathena.converter import _to_array, _to_map, _to_struct
 from pyathena.cursor import Cursor
 from pyathena.error import DatabaseError, NotSupportedError, ProgrammingError
 from pyathena.model import AthenaQueryExecution
+from pyathena.util import RetryConfig
 from tests import ENV
 from tests.pyathena.conftest import connect
 
@@ -878,6 +879,70 @@ class TestCursor:
         assert from_options == []
         assert from_kwargs == [cursor.query_id]
         assert cursor.fetchone() == (1,)
+
+    def test_execute_internal_legacy_kwargs(self, cursor):
+        """The private _execute() accepts the pre-3.35 individual keyword arguments.
+
+        Regression test for #734: external callers such as dbt-athena <= 1.10.x
+        invoke _execute() directly with individual keywords instead of options.
+        """
+        query_id = cursor._execute(
+            "SELECT 1",
+            parameters=None,
+            work_group=ENV.default_work_group,
+            s3_staging_dir=None,
+            cache_size=0,
+            cache_expiration_time=0,
+        )
+        query_execution = cursor._poll(query_id)
+        assert query_execution.state == AthenaQueryExecution.STATE_SUCCEEDED
+
+    def test_execute_internal_legacy_kwargs_passthrough(self):
+        """The pre-3.35 _execute() keywords are forwarded to the request (no AWS).
+
+        Regression test for #734: on 3.35.0 this call raised
+        ``TypeError: _execute() got an unexpected keyword argument 'work_group'``.
+        """
+        cursor = Cursor.__new__(Cursor)  # bypass __init__ to avoid AWS calls
+        cursor._connection = MagicMock()
+        cursor._connection.client.start_query_execution.return_value = {
+            "QueryExecutionId": "test_query_id"
+        }
+        cursor._retry_config = RetryConfig()
+
+        with (
+            patch.object(
+                Cursor, "_build_start_query_execution_request", return_value={}
+            ) as request_mock,
+            patch.object(Cursor, "_find_previous_query_id", return_value=None) as cache_mock,
+        ):
+            query_id = cursor._execute(
+                "SELECT 1",
+                parameters=None,
+                work_group="test_work_group",
+                s3_staging_dir="s3://test-bucket/path/",
+                cache_size=10,
+                cache_expiration_time=100,
+                result_reuse_enable=True,
+                result_reuse_minutes=5,
+                paramstyle="qmark",
+            )
+
+        assert query_id == "test_query_id"
+        request_mock.assert_called_once_with(
+            query="SELECT 1",
+            work_group="test_work_group",
+            s3_staging_dir="s3://test-bucket/path/",
+            result_reuse_enable=True,
+            result_reuse_minutes=5,
+            execution_parameters=None,
+        )
+        cache_mock.assert_called_once_with(
+            "SELECT 1",
+            "test_work_group",
+            cache_size=10,
+            cache_expiration_time=100,
+        )
 
     def test_connection_level_callback(self):
         """Test connection-level default callback."""


### PR DESCRIPTION
## WHAT

Restore the pre-3.35 individual keyword arguments (`work_group`, `s3_staging_dir`, `cache_size`, `cache_expiration_time`, `result_reuse_enable`, `result_reuse_minutes`, `paramstyle`) on `BaseCursor._execute()` and `AioBaseCursor._execute()`. The keywords are merged into `ExecuteOptions` via the existing `ExecuteOptions.resolve()` (individual keywords win, `None` values are ignored), so the ExecuteOptions consolidation from #733 is otherwise unchanged.

Regression tests added:

- `test_execute_internal_legacy_kwargs` (sync, integration): replicates the exact dbt-athena call pattern (`_execute()` with individual keywords, then `_poll()`) against real Athena.
- `test_execute_internal_legacy_kwargs_passthrough` (sync + aio, no AWS): calls `_execute()` with all legacy keywords mocked at the API boundary and asserts they are forwarded into the start-query-execution request and the cache lookup. These tests fail with the reported `TypeError` on the v3.35.0 code, so the compat surface is now guarded in CI without AWS credentials.

## WHY

v3.35.0 (#733) narrowed the private `_execute()` signature to `(operation, parameters, options)`. dbt-athena <= 1.10.x bypasses the public `execute()` (which kept full backward compatibility) and calls `_execute()` directly with individual keywords, so every dbt-athena user resolving to pyathena 3.35.0 fails with:

```
TypeError: BaseCursor._execute() got an unexpected keyword argument 'work_group'
```

Closes #734. Reported upstream in dbt-labs/dbt-adapters#2052.

Notes:

- The v3.34 parameter order is restored with `options` appended last, so v3.34-era positional callers also keep working. A caller that adopted the one-day-old 3.35.0 signature *positionally* (`_execute(op, params, options)`) would misbind; all known external callers pass keywords, and v3.34 compatibility takes priority.
- Will be released as **v3.35.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)