### PR TITLE
Fix/739 cache schema catalog

### DIFF
--- a/pyathena/aio/common.py
+++ b/pyathena/aio/common.py
@@ -220,8 +220,8 @@ class AioBaseCursor(BaseCursor):
                         break
                     if (
                         execution.query == query
-                        and (self._schema_name is None or execution.database == self._schema_name)
-                        and (self._catalog_name is None or execution.catalog == self._catalog_name)
+                        and execution.database == self._schema_name
+                        and execution.catalog == self._catalog_name
                     ):
                         query_id = execution.query_id
                         break

--- a/pyathena/aio/common.py
+++ b/pyathena/aio/common.py
@@ -221,7 +221,7 @@ class AioBaseCursor(BaseCursor):
                     if (
                         execution.query == query
                         and execution.database == self._schema_name
-                        and execution.catalog == self._catalog_name
+                        and (execution.catalog or "").lower() == (self._catalog_name or "").lower()
                     ):
                         query_id = execution.query_id
                         break

--- a/pyathena/aio/common.py
+++ b/pyathena/aio/common.py
@@ -218,7 +218,11 @@ class AioBaseCursor(BaseCursor):
                     ):
                         next_token = None
                         break
-                    if execution.query == query:
+                    if (
+                        execution.query == query
+                        and (self._schema_name is None or execution.database == self._schema_name)
+                        and (self._catalog_name is None or execution.catalog == self._catalog_name)
+                    ):
                         query_id = execution.query_id
                         break
                 if query_id or next_token is None:

--- a/pyathena/common.py
+++ b/pyathena/common.py
@@ -638,7 +638,11 @@ class BaseCursor(metaclass=ABCMeta):
                     ):
                         next_token = None
                         break
-                    if execution.query == query:
+                    if (
+                        execution.query == query
+                        and (self._schema_name is None or execution.database == self._schema_name)
+                        and (self._catalog_name is None or execution.catalog == self._catalog_name)
+                    ):
                         query_id = execution.query_id
                         break
                 if query_id or next_token is None:

--- a/pyathena/common.py
+++ b/pyathena/common.py
@@ -641,7 +641,7 @@ class BaseCursor(metaclass=ABCMeta):
                     if (
                         execution.query == query
                         and execution.database == self._schema_name
-                        and execution.catalog == self._catalog_name
+                        and (execution.catalog or "").lower() == (self._catalog_name or "").lower()
                     ):
                         query_id = execution.query_id
                         break

--- a/pyathena/common.py
+++ b/pyathena/common.py
@@ -640,8 +640,8 @@ class BaseCursor(metaclass=ABCMeta):
                         break
                     if (
                         execution.query == query
-                        and (self._schema_name is None or execution.database == self._schema_name)
-                        and (self._catalog_name is None or execution.catalog == self._catalog_name)
+                        and execution.database == self._schema_name
+                        and execution.catalog == self._catalog_name
                     ):
                         query_id = execution.query_id
                         break

--- a/tests/pyathena/aio/test_cursor.py
+++ b/tests/pyathena/aio/test_cursor.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -149,7 +149,7 @@ class TestAioCursor:
                         "QueryExecutionContext": {"Database": schema},
                         "Status": {
                             "State": AthenaQueryExecution.STATE_SUCCEEDED,
-                            "CompletionDateTime": datetime.now(),
+                            "CompletionDateTime": datetime.now(timezone.utc),
                         },
                     }
                 }
@@ -170,6 +170,45 @@ class TestAioCursor:
             assert (
                 await cursor._find_previous_query_id(query, None, cache_size=100)
                 == "query_id_other_schema"
+            )
+
+    async def test_cache_size_different_catalog(self):
+        query = "SELECT * FROM one_row"
+        schema = "this_schema"
+
+        def execution(catalog):
+            return AthenaQueryExecution(
+                {
+                    "QueryExecution": {
+                        "QueryExecutionId": f"query_id_{catalog}",
+                        "Query": query,
+                        "StatementType": AthenaQueryExecution.STATEMENT_TYPE_DML,
+                        "QueryExecutionContext": {"Database": schema, "Catalog": catalog},
+                        "Status": {
+                            "State": AthenaQueryExecution.STATE_SUCCEEDED,
+                            "CompletionDateTime": datetime.now(timezone.utc),
+                        },
+                    }
+                }
+            )
+
+        cursor = AioCursor.__new__(AioCursor)
+        cursor._schema_name = schema
+
+        with patch.object(
+            AioCursor,
+            "_list_query_executions",
+            new_callable=AsyncMock,
+            return_value=(None, [execution("awsdatacatalog")]),
+        ):
+            # A different catalog must not be a cache hit.
+            cursor._catalog_name = "other_catalog"
+            assert await cursor._find_previous_query_id(query, None, cache_size=100) is None
+            # The same catalog, differing only in case, must still be a cache hit.
+            cursor._catalog_name = "AwsDataCatalog"
+            assert (
+                await cursor._find_previous_query_id(query, None, cache_size=100)
+                == "query_id_awsdatacatalog"
             )
 
     async def test_no_result_set_raises(self, aio_cursor):

--- a/tests/pyathena/aio/test_cursor.py
+++ b/tests/pyathena/aio/test_cursor.py
@@ -130,6 +130,48 @@ class TestAioCursor:
             cache_expiration_time=100,
         )
 
+    async def test_cache_size_different_schema(self):
+        """A cached result is only reused when it ran against the same schema (#739).
+
+        Mirrors the synchronous cursor test: identical SQL can resolve to different
+        tables depending on the database it runs against, so a prior execution from
+        another schema must not be a cache hit.
+        """
+        query = "SELECT * FROM one_row"
+
+        def execution(schema):
+            return AthenaQueryExecution(
+                {
+                    "QueryExecution": {
+                        "QueryExecutionId": f"query_id_{schema}",
+                        "Query": query,
+                        "StatementType": AthenaQueryExecution.STATEMENT_TYPE_DML,
+                        "QueryExecutionContext": {"Database": schema},
+                        "Status": {
+                            "State": AthenaQueryExecution.STATE_SUCCEEDED,
+                            "CompletionDateTime": datetime.now(),
+                        },
+                    }
+                }
+            )
+
+        cursor = AioCursor.__new__(AioCursor)  # bypass __init__ to avoid AWS calls
+        cursor._catalog_name = None
+
+        with patch.object(
+            AioCursor,
+            "_list_query_executions",
+            new_callable=AsyncMock,
+            return_value=(None, [execution("other_schema")]),
+        ):
+            cursor._schema_name = "this_schema"
+            assert await cursor._find_previous_query_id(query, None, cache_size=100) is None
+            cursor._schema_name = "other_schema"
+            assert (
+                await cursor._find_previous_query_id(query, None, cache_size=100)
+                == "query_id_other_schema"
+            )
+
     async def test_no_result_set_raises(self, aio_cursor):
         with pytest.raises(ProgrammingError):
             await aio_cursor.fetchone()

--- a/tests/pyathena/test_cursor.py
+++ b/tests/pyathena/test_cursor.py
@@ -223,6 +223,42 @@ class TestCursor:
                 == "query_id_other_schema"
             )
 
+    def test_cache_size_different_catalog(self):
+        query = "SELECT * FROM one_row"
+        schema = "this_schema"
+
+        def execution(catalog):
+            return AthenaQueryExecution(
+                {
+                    "QueryExecution": {
+                        "QueryExecutionId": f"query_id_{catalog}",
+                        "Query": query,
+                        "StatementType": AthenaQueryExecution.STATEMENT_TYPE_DML,
+                        "QueryExecutionContext": {"Database": schema, "Catalog": catalog},
+                        "Status": {
+                            "State": AthenaQueryExecution.STATE_SUCCEEDED,
+                            "CompletionDateTime": datetime.now(timezone.utc),
+                        },
+                    }
+                }
+            )
+
+        cursor = Cursor.__new__(Cursor)
+        cursor._schema_name = schema
+
+        with patch.object(
+            Cursor, "_list_query_executions", return_value=(None, [execution("awsdatacatalog")])
+        ):
+            # A different catalog must not be a cache hit.
+            cursor._catalog_name = "other_catalog"
+            assert cursor._find_previous_query_id(query, None, cache_size=100) is None
+            # The same catalog, differing only in case, must still be a cache hit
+            cursor._catalog_name = "AwsDataCatalog"
+            assert (
+                cursor._find_previous_query_id(query, None, cache_size=100)
+                == "query_id_awsdatacatalog"
+            )
+
     @pytest.mark.parametrize(
         "cursor",
         [{"work_group": ENV.work_group, "result_reuse_enable": True, "result_reuse_minutes": 5}],

--- a/tests/pyathena/test_cursor.py
+++ b/tests/pyathena/test_cursor.py
@@ -185,6 +185,44 @@ class TestCursor:
         assert query_id_7 != query_id_8
         assert query_id_9 in [query_id_7, query_id_8]
 
+    def test_cache_size_different_schema(self):
+        """A cached result is only reused when it ran against the same schema (#739).
+
+        Identical SQL can resolve to different tables depending on the database it
+        runs against, so a prior execution from another schema must not be a cache hit.
+        """
+        query = "SELECT * FROM one_row"
+
+        def execution(schema):
+            return AthenaQueryExecution(
+                {
+                    "QueryExecution": {
+                        "QueryExecutionId": f"query_id_{schema}",
+                        "Query": query,
+                        "StatementType": AthenaQueryExecution.STATEMENT_TYPE_DML,
+                        "QueryExecutionContext": {"Database": schema},
+                        "Status": {
+                            "State": AthenaQueryExecution.STATE_SUCCEEDED,
+                            "CompletionDateTime": datetime.now(timezone.utc),
+                        },
+                    }
+                }
+            )
+
+        cursor = Cursor.__new__(Cursor)  # bypass __init__ to avoid AWS calls
+        cursor._catalog_name = None
+
+        with patch.object(
+            Cursor, "_list_query_executions", return_value=(None, [execution("other_schema")])
+        ):
+            cursor._schema_name = "this_schema"
+            assert cursor._find_previous_query_id(query, None, cache_size=100) is None
+            cursor._schema_name = "other_schema"
+            assert (
+                cursor._find_previous_query_id(query, None, cache_size=100)
+                == "query_id_other_schema"
+            )
+
     @pytest.mark.parametrize(
         "cursor",
         [{"work_group": ENV.work_group, "result_reuse_enable": True, "result_reuse_minutes": 5}],


### PR DESCRIPTION
## WHAT
Check the database name and the catalog are the same for a request before allowing a query cache hit. See #739. 

## WHY
When the pyathena cache is checked for hits, queries from the given workgroup are checked for having the same query string, but NOT whether they were queried against the same Catalog or DatabaseName. Thus queries among multiple environments with the same table names and schemas (e.g., dev vs. prod catalogs or databases) will cause spurious cache hits from the other environment, possibly with erroneous data.