### PR TITLE
fix(sqlalchemy): return the formatted DATE literal from AthenaDate.process

### DIFF
--- a/pyathena/sqlalchemy/types.py
+++ b/pyathena/sqlalchemy/types.py
@@ -81,7 +81,7 @@ class AthenaDate(TypeEngine[date]):
     @staticmethod
     def process(value: date | datetime | Any) -> str:
         if isinstance(value, (date, datetime)):
-            f"DATE '{value:%Y-%m-%d}'"
+            return f"DATE '{value:%Y-%m-%d}'"
         return f"DATE '{value!s}'"
 
     def literal_processor(self, dialect: Dialect) -> _LiteralProcessorType[date] | None:

--- a/tests/pyathena/sqlalchemy/test_types.py
+++ b/tests/pyathena/sqlalchemy/test_types.py
@@ -1,3 +1,5 @@
+from datetime import date, datetime
+
 import pytest
 from sqlalchemy import Integer, String, types
 from sqlalchemy.sql import sqltypes
@@ -7,6 +9,7 @@ from pyathena.sqlalchemy.types import (
     MAP,
     STRUCT,
     AthenaArray,
+    AthenaDate,
     AthenaMap,
     AthenaStruct,
     get_double_type,
@@ -163,3 +166,15 @@ def test_get_double_type():
     else:
         assert result is types.FLOAT
     assert ischema_names["double"] is result
+
+
+class TestAthenaDate:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (date(2017, 1, 1), "DATE '2017-01-01'"),
+            (datetime(2017, 1, 1, 12, 34, 56), "DATE '2017-01-01'"),
+        ],
+    )
+    def test_process_renders_date_only_literal(self, value, expected):
+        assert AthenaDate.process(value) == expected


### PR DESCRIPTION
Closes #742

## WHAT
`AthenaDate.process` now returns the `DATE 'YYYY-MM-DD'` literal it builds in the `date`/`datetime` branch, instead of discarding it and falling through to `DATE '{value!s}'`. Adds a regression test covering both a `date` and a `datetime` input.

## WHY
The `if` branch evaluated the f-string without returning it, so a `datetime` rendered as `DATE '2017-01-01 12:00:00'` — not a valid Athena `DATE` literal. `pyathena/formatter.py` already formats it correctly.
