### PR TITLE
test(sqlalchemy): cover AthenaTimestamp.process and simplify AthenaDate isinstance

### DIFF
--- a/pyathena/sqlalchemy/types.py
+++ b/pyathena/sqlalchemy/types.py
@@ -79,8 +79,10 @@ class AthenaDate(TypeEngine[date]):
     render_bind_cast = True
 
     @staticmethod
-    def process(value: date | datetime | Any) -> str:
-        if isinstance(value, (date, datetime)):
+    def process(value: date | Any) -> str:
+        # datetime is a subclass of date, so this branch also covers datetime,
+        # which is truncated to its date part.
+        if isinstance(value, date):
             return f"DATE '{value:%Y-%m-%d}'"
         return f"DATE '{value!s}'"
 

--- a/tests/pyathena/sqlalchemy/test_types.py
+++ b/tests/pyathena/sqlalchemy/test_types.py
@@ -12,6 +12,7 @@ from pyathena.sqlalchemy.types import (
     AthenaDate,
     AthenaMap,
     AthenaStruct,
+    AthenaTimestamp,
     get_double_type,
 )
 
@@ -178,3 +179,32 @@ class TestAthenaDate:
     )
     def test_process_renders_date_only_literal(self, value, expected):
         assert AthenaDate.process(value) == expected
+
+    def test_process_falls_back_to_str(self):
+        assert AthenaDate.process("2017-01-01") == "DATE '2017-01-01'"
+
+
+class TestAthenaTimestamp:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            # Athena TIMESTAMP has millisecond precision, so the six digits
+            # strftime("%f") emits are truncated to three.
+            (
+                datetime(2017, 1, 1, 12, 34, 56, 789012),
+                "TIMESTAMP '2017-01-01 12:34:56.789'",
+            ),
+            (
+                datetime(2017, 1, 1, 12, 34, 56),
+                "TIMESTAMP '2017-01-01 12:34:56.000'",
+            ),
+        ],
+    )
+    def test_process_renders_millisecond_precision_literal(self, value, expected):
+        assert AthenaTimestamp.process(value) == expected
+
+    def test_process_falls_back_to_str(self):
+        assert (
+            AthenaTimestamp.process("2017-01-01 12:34:56.789")
+            == "TIMESTAMP '2017-01-01 12:34:56.789'"
+        )


### PR DESCRIPTION
Follow-up to #743.

## WHAT

- Add `TestAthenaTimestamp` covering `AthenaTimestamp.process`: the millisecond truncation, a whole-second `datetime`, and the non-`datetime` fallback. Add the matching fallback case to `TestAthenaDate`.
- Simplify `AthenaDate.process`: `isinstance(value, (date, datetime))` → `isinstance(value, date)`, and narrow the annotation to `date | Any`.

## WHY

#743 fixed a missing `return` in `AthenaDate.process`. Its sibling `AthenaTimestamp.process` is correct today, but had no test — nothing guarded the `strftime("%f")[:-3]` slice that narrows six digits to the three Athena `TIMESTAMP` supports. These are pure-logic tests, so they need no AWS credentials.

`datetime` is a subclass of `date`, so the tuple in the `isinstance` check was redundant and the `date | datetime | Any` annotation collapsed to `Any`.

### Sweep for the same bug class

Since #742 was a computed-then-discarded expression, I checked whether the tree holds others. **No ruff rule catches this** — `B018` deliberately skips strings so it cannot see a bare f-string, and `--select ALL` on a reduced case reports nothing. An AST walk over `pyathena/`, `tests/`, and `benchmarks/` for discarded `ast.Expr` statements returned two hits, both legitimate:

- `pyathena/common.py:33` — PEP 258 attribute docstring for the `OnPollCallback` alias
- `tests/pyathena/sqlalchemy/test_types.py:76` — intentional `__getitem__` inside `pytest.raises(KeyError)`

**#742 was the only real instance.**